### PR TITLE
datadog apm: propagate errors to APM

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1585,7 +1585,7 @@
   version = "v1.11.3"
 
 [[projects]]
-  digest = "1:8e7e862affe62ca299b3c4acfb6bfcbc156a28f16592eca50aa81e46f3f8816f"
+  digest = "1:dfa85ea7e0f402e82727c055cec1a7dfc95ffa7754ba417f672876e4baf497db"
   name = "gopkg.in/DataDog/dd-trace-go.v1"
   packages = [
     "contrib/gorilla/mux",
@@ -1597,8 +1597,8 @@
     "ddtrace/tracer",
   ]
   pruneopts = ""
-  revision = "823d51722f66a748804943f6fa6be18776073b82"
-  version = "v1.9.0"
+  revision = "fd9dc1465a7f279ce06639563428b56b01c3b146"
+  version = "v1.10.0"
 
 [[projects]]
   branch = "v1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -146,4 +146,4 @@
 
 [[constraint]]
   name = "gopkg.in/DataDog/dd-trace-go.v1"
-  version = "1.9.0"
+  version = "1.10.0"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,8 +17,6 @@ var awsCreds config.AWSCreds
 var awsConfig config.AWSConfig
 var secretsConfig config.SecretsConfig
 var secretsbackend string
-var dogstatsdAddr, dogstatsdTags string
-var datadogServiceName, datadogTracingAgentAddr string
 
 var RootCmd = &cobra.Command{
 	Use:   "acyl",
@@ -40,10 +38,6 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&vaultConfig.UserIDPath, "vault-user-id-path", "e", os.Getenv("USER_ID_PATH"), "Path to file containing Vault User-ID (if using Vault secret backend)")
 	RootCmd.PersistentFlags().StringVarP(&awsConfig.Region, "aws-region", "k", "us-west-2", "AWS region")
 	RootCmd.PersistentFlags().UintVarP(&awsConfig.MaxRetries, "aws-max-retries", "l", 3, "AWS max retries per operation")
-	RootCmd.PersistentFlags().StringVarP(&dogstatsdAddr, "dogstatsd-addr", "q", "127.0.0.1:8125", "Address of dogstatsd for metrics")
-	RootCmd.PersistentFlags().StringVar(&dogstatsdTags, "dogstatsd-tags", "", "Comma-separated list of tags to add to dogstatsd metrics (TAG:VALUE)")
-	RootCmd.PersistentFlags().StringVar(&datadogTracingAgentAddr, "datadog-tracing-agent-addr", "127.0.0.1:8126", "Address of datadog tracing agent")
-	RootCmd.PersistentFlags().StringVar(&datadogServiceName, "datadog-service-name", "acyl", "Default service name to be used for Datadog APM")
 	RootCmd.PersistentFlags().StringVar(&secretsbackend, "secrets-backend", "vault", "Secret backend (one of: vault,env)")
 	RootCmd.PersistentFlags().StringVar(&secretsConfig.Mapping, "secrets-mapping", "", "Secrets mapping template string (required)")
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -59,6 +59,8 @@ var furanHostStr string
 var aminoAddr string
 var s3config config.S3Config
 var failureTemplatePath string
+var dogstatsdAddr, dogstatsdTags string
+var datadogServiceName, datadogTracingAgentAddr string
 
 // serverCmd represents the server command
 var serverCmd = &cobra.Command{
@@ -107,6 +109,10 @@ func init() {
 	serverCmd.PersistentFlags().StringVar(&s3config.Region, "failure-report-s3-region", "us-west-2", "AWS S3 region for environment failure reports")
 	serverCmd.PersistentFlags().StringVar(&s3config.Bucket, "failure-report-s3-bucket", "", "AWS S3 bucket for environment failure reports")
 	serverCmd.PersistentFlags().StringVar(&s3config.KeyPrefix, "failure-report-s3-key-prefix", "", "AWS S3 key prefix for environment failure reports (key format: <prefix>envfailures/<timestamp>/<env name>.html)")
+	serverCmd.PersistentFlags().StringVarP(&dogstatsdAddr, "dogstatsd-addr", "q", "127.0.0.1:8125", "Address of dogstatsd for metrics")
+	serverCmd.PersistentFlags().StringVar(&dogstatsdTags, "dogstatsd-tags", "", "Comma-separated list of tags to add to dogstatsd metrics (TAG:VALUE)")
+	serverCmd.PersistentFlags().StringVar(&datadogTracingAgentAddr, "datadog-tracing-agent-addr", "127.0.0.1:8126", "Address of datadog tracing agent")
+	serverCmd.PersistentFlags().StringVar(&datadogServiceName, "datadog-service-name", "acyl", "Default service name to be used for Datadog APM")
 	RootCmd.AddCommand(serverCmd)
 }
 

--- a/pkg/api/api_v0.go
+++ b/pkg/api/api_v0.go
@@ -189,45 +189,48 @@ func (api *v0api) githubWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		api.wg.Add(1)
 		go func() {
 			var err error
-			defer rootSpan.Finish(tracer.WithError(err))
 			defer api.wg.Done()
 			ctx, cf := context.WithTimeout(ctx, MaxAsyncActionTimeout)
 			defer cf() // guarantee that any goroutines created with the ctx are cancelled
 			name, err := api.es.Create(ctx, *out.RRD)
 			if err != nil {
 				log("finished processing create with error: %v", err)
+				rootSpan.Finish(tracer.WithError(err))
 				return
 			}
+			rootSpan.Finish()
 			log("success processing create event (env: %q); done", name)
 		}()
 	case ghevent.Update:
 		api.wg.Add(1)
 		go func() {
 			var err error
-			defer rootSpan.Finish(tracer.WithError(err))
 			defer api.wg.Done()
 			ctx, cf := context.WithTimeout(ctx, MaxAsyncActionTimeout)
 			defer cf() // guarantee that any goroutines created with the ctx are cancelled
 			name, err := api.es.Update(ctx, *out.RRD)
 			if err != nil {
 				log("finished processing update with error: %v", err)
+				rootSpan.Finish(tracer.WithError(err))
 				return
 			}
+			rootSpan.Finish()
 			log("success processing update event (env: %q); done", name)
 		}()
 	case ghevent.Destroy:
 		api.wg.Add(1)
 		go func() {
 			var err error
-			defer rootSpan.Finish(tracer.WithError(err))
 			defer api.wg.Done()
 			ctx, cf := context.WithTimeout(ctx, MaxAsyncActionTimeout)
 			defer cf() // guarantee that any goroutines created with the ctx are cancelled
 			err = api.es.Destroy(ctx, *out.RRD, models.DestroyApiRequest)
 			if err != nil {
 				log("finished processing destroy with error: %v", err)
+				rootSpan.Finish(tracer.WithError(err))
 				return
 			}
+			rootSpan.Finish()
 			log("success processing destroy event; done")
 		}()
 	default:

--- a/pkg/nitro/env/env.go
+++ b/pkg/nitro/env/env.go
@@ -150,7 +150,9 @@ func (m *Manager) pushNotification(ctx context.Context, env *newEnv, event notif
 
 func (m *Manager) createPendingGithubStatus(ctx context.Context, rd *models.RepoRevisionData) (err error) {
 	span, _ := tracer.StartSpanFromContext(ctx, "create_pending_github_status")
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	cs := &ghclient.CommitStatus{
 		Context:     "Acyl",
 		Status:      "pending",
@@ -266,13 +268,13 @@ func (m *Manager) getRepoConfig(ctx context.Context, rd *models.RepoRevisionData
 
 // generateNewEnv calculates the metadata for a new environment and either creates a new environment DB record or modifies an existing one
 func (m *Manager) generateNewEnv(ctx context.Context, rd *models.RepoRevisionData) (env *models.QAEnvironment, err error) {
+	span, _ := tracer.StartSpanFromContext(ctx, "generate_new_env")
 	defer func() {
 		if err != nil {
 			err = nitroerrors.SystemError(err)
 		}
+		span.Finish(tracer.WithError(err))
 	}()
-	span, _ := tracer.StartSpanFromContext(ctx, "generate_new_env")
-	defer span.Finish(tracer.WithError(err))
 	envs, err := m.DL.GetQAEnvironmentsByRepoAndPR(rd.Repo, rd.PullRequest)
 	if err != nil {
 		return nil, errors.Wrap(err, "error checking for existing environment record")
@@ -326,13 +328,13 @@ func (m *Manager) generateNewEnv(ctx context.Context, rd *models.RepoRevisionDat
 
 // processEnvConfig fetches, parses and validates the top-level acyl.yml and all dependencies, calculates refs and writes them to the env db record. It always returns a valid *newEnv regardless of error.
 func (m *Manager) processEnvConfig(ctx context.Context, env *models.QAEnvironment, rd *models.RepoRevisionData) (ne *newEnv, err error) {
+	span, _ := tracer.StartSpanFromContext(ctx, "process_env_config")
 	defer func() {
 		if err != nil && !nitroerrors.IsUserError(err) {
 			err = nitroerrors.SystemError(err)
 		}
+		span.Finish(tracer.WithError(err))
 	}()
-	span, _ := tracer.StartSpanFromContext(ctx, "process_env_config")
-	defer span.Finish(tracer.WithError(err))
 	ne = &newEnv{env: env}
 	rc, err := m.getRepoConfig(ctx, rd)
 	if err != nil {
@@ -366,7 +368,9 @@ func (m *Manager) processEnvConfig(ctx context.Context, env *models.QAEnvironmen
 
 func (m *Manager) fetchCharts(ctx context.Context, name string, rc *models.RepoConfig) (_ string, _ meta.ChartLocations, err error) {
 	span, _ := tracer.StartSpanFromContext(ctx, "fetch_charts")
-	defer span.Finish(tracer.WithError(err))
+	defer func() {
+		span.Finish(tracer.WithError(err))
+	}()
 	td, err := tempDir(m.FS, "", name)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "error generating temp dir")
@@ -388,9 +392,9 @@ func (m *Manager) fetchCharts(ctx context.Context, name string, rc *models.RepoC
 func (m *Manager) create(ctx context.Context, rd *models.RepoRevisionData) (envname string, err error) {
 	end := m.MC.Timing(mpfx+"create", "triggering_repo:"+rd.Repo)
 	span, ctx := tracer.StartSpanFromContext(ctx, "create")
-	defer span.Finish(tracer.WithError(err))
 	defer func() {
 		end(fmt.Sprintf("success:%v", err == nil))
+		span.Finish(tracer.WithError(err))
 	}()
 	env, err := m.generateNewEnv(ctx, rd)
 	if err != nil {
@@ -436,11 +440,12 @@ func (m *Manager) create(ctx context.Context, rd *models.RepoRevisionData) (envn
 			VarFilePath: v.VarFilePath,
 		}
 	}
-	chartSpan, _ := tracer.StartSpanFromContext(ctx, "build_and_install_chart")
-	defer chartSpan.Finish(tracer.WithError(err))
+	chartSpan, ctx := tracer.StartSpanFromContext(ctx, "build_and_install_chart")
 	if err = m.CI.BuildAndInstallCharts(ctx, &metahelm.EnvInfo{Env: newenv.env, RC: newenv.rc}, mcloc); err != nil {
+		chartSpan.Finish(tracer.WithError(err))
 		return "", m.handleMetahelmError(ctx, newenv, err, "error installing charts")
 	}
+	chartSpan.Finish()
 	return newenv.env.Name, nil
 }
 
@@ -471,9 +476,9 @@ func (m *Manager) getenv(ctx context.Context, rd *models.RepoRevisionData) (*mod
 func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reason models.QADestroyReason) (err error) {
 	end := m.MC.Timing(mpfx+"delete", "triggering_repo:"+rd.Repo)
 	span, ctx := tracer.StartSpanFromContext(ctx, "delete")
-	defer span.Finish(tracer.WithError(err))
 	defer func() {
 		end(fmt.Sprintf("success:%v", err == nil))
+		span.Finish(tracer.WithError(err))
 	}()
 	env, err := m.getenv(ctx, rd)
 	if err != nil {
@@ -548,9 +553,9 @@ func (m *Manager) Update(ctx context.Context, rd models.RepoRevisionData) (strin
 func (m *Manager) update(ctx context.Context, rd *models.RepoRevisionData) (envname string, err error) {
 	end := m.MC.Timing(mpfx+"update", "triggering_repo:"+rd.Repo)
 	span, ctx := tracer.StartSpanFromContext(ctx, "update")
-	defer span.Finish(tracer.WithError(err))
 	defer func() {
 		end(fmt.Sprintf("success:%v", err == nil))
+		span.Finish(tracer.WithError(err))
 	}()
 	// check config signatures, if match then we can do chart upgrades
 	// if mismatch, then tear down existing env and rebuild from scratch

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/README.md
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/README.md
@@ -7,6 +7,8 @@ them to be used as they normally would with tracing activated out of the box.
 
 All of these libraries are supported by our [APM product](https://www.datadoghq.com/apm/).
 
+:warning: These libraries are not built to be used with Opentracing. Opentracing integrations can be found in [their own organisation](https://github.com/opentracing-contrib/).
+
 ### Usage
 
 First, find the library which you'd like to integrate with. The naming convention for the integration packages is:

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis/redis.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis/redis.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -20,6 +21,9 @@ import (
 type Client struct {
 	*redis.Client
 	*params
+
+	mu  sync.RWMutex // guards ctx
+	ctx context.Context
 }
 
 var _ redis.Cmdable = (*Client)(nil)
@@ -28,6 +32,8 @@ var _ redis.Cmdable = (*Client)(nil)
 type Pipeliner struct {
 	redis.Pipeliner
 	*params
+
+	ctx context.Context
 }
 
 var _ redis.Pipeliner = (*Pipeliner)(nil)
@@ -65,14 +71,17 @@ func WrapClient(c *redis.Client, opts ...ClientOption) *Client {
 		db:     strconv.Itoa(opt.DB),
 		config: cfg,
 	}
-	tc := &Client{c, params}
+	tc := &Client{Client: c, params: params}
 	tc.Client.WrapProcess(createWrapperFromClient(tc))
 	return tc
 }
 
 // Pipeline creates a Pipeline from a Client
 func (c *Client) Pipeline() redis.Pipeliner {
-	return &Pipeliner{c.Client.Pipeline(), c.params}
+	c.mu.RLock()
+	ctx := c.ctx
+	c.mu.RUnlock()
+	return &Pipeliner{c.Client.Pipeline(), c.params, ctx}
 }
 
 // ExecWithContext calls Pipeline.Exec(). It ensures that the resulting Redis calls
@@ -83,7 +92,7 @@ func (c *Pipeliner) ExecWithContext(ctx context.Context) ([]redis.Cmder, error) 
 
 // Exec calls Pipeline.Exec() ensuring that the resulting Redis calls are traced.
 func (c *Pipeliner) Exec() ([]redis.Cmder, error) {
-	return c.execWithContext(context.Background())
+	return c.execWithContext(c.ctx)
 }
 
 func (c *Pipeliner) execWithContext(ctx context.Context) ([]redis.Cmder, error) {
@@ -120,8 +129,18 @@ func commandsToString(cmds []redis.Cmder) string {
 
 // WithContext sets a context on a Client. Use it to ensure that emitted spans have the correct parent.
 func (c *Client) WithContext(ctx context.Context) *Client {
-	c.Client = c.Client.WithContext(ctx)
+	c.mu.Lock()
+	c.ctx = ctx
+	c.mu.Unlock()
 	return c
+}
+
+// Context returns the active context in the client.
+func (c *Client) Context() context.Context {
+	c.mu.RLock()
+	ctx := c.ctx
+	c.mu.RUnlock()
+	return ctx
 }
 
 // createWrapperFromClient returns a new createWrapper function which wraps the processor with tracing
@@ -130,7 +149,9 @@ func (c *Client) WithContext(ctx context.Context) *Client {
 func createWrapperFromClient(tc *Client) func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
 	return func(oldProcess func(cmd redis.Cmder) error) func(cmd redis.Cmder) error {
 		return func(cmd redis.Cmder) error {
-			ctx := tc.Client.Context()
+			tc.mu.RLock()
+			ctx := tc.ctx
+			tc.mu.RUnlock()
 			raw := cmderToString(cmd)
 			parts := strings.Split(raw, " ")
 			length := len(parts) - 1

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis/redis_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/go-redis/redis/redis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ func TestMain(m *testing.M) {
 	}
 	os.Exit(m.Run())
 }
+
 func TestClientEvalSha(t *testing.T) {
 	opts := &redis.Options{Addr: "127.0.0.1:6379"}
 	assert := assert.New(t)
@@ -48,6 +50,27 @@ func TestClientEvalSha(t *testing.T) {
 	assert.Equal("127.0.0.1", span.Tag(ext.TargetHost))
 	assert.Equal("6379", span.Tag(ext.TargetPort))
 	assert.Equal("evalsha", span.Tag(ext.ResourceName))
+}
+
+// https://github.com/DataDog/dd-trace-go/issues/387
+func TestIssue387(t *testing.T) {
+	opts := &redis.Options{Addr: "127.0.0.1:6379"}
+	client := NewClient(opts, WithServiceName("my-redis"))
+	n := 1000
+
+	client.Set("test_key", "test_value", 0)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			client.WithContext(context.Background()).Get("test_key").Result()
+		}()
+	}
+	wg.Wait()
+
+	// should not result in a race
 }
 
 func TestClient(t *testing.T) {

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/client.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/client.go
@@ -26,7 +26,7 @@ func (cs *clientStream) RecvMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer finishWithError(span, err, cs.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, cs.cfg.noDebugStack) }()
 	}
 	err = cs.ClientStream.RecvMsg(m)
 	return err
@@ -38,7 +38,7 @@ func (cs *clientStream) SendMsg(m interface{}) (err error) {
 		if p, ok := peer.FromContext(cs.Context()); ok {
 			setSpanTargetFromPeer(span, *p)
 		}
-		defer finishWithError(span, err, cs.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, cs.cfg.noDebugStack) }()
 	}
 	err = cs.ClientStream.SendMsg(m)
 	return err

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/grpc.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/grpc.go
@@ -33,8 +33,11 @@ func startSpanFromContext(ctx context.Context, method, operation, service string
 
 // finishWithError applies finish option and a tag with gRPC status code, disregarding OK, EOF and Canceled errors.
 func finishWithError(span ddtrace.Span, err error, noDebugStack bool) {
+	if err == io.EOF || err == context.Canceled {
+		err = nil
+	}
 	errcode := status.Code(err)
-	if err == io.EOF || errcode == codes.Canceled || errcode == codes.OK || err == context.Canceled {
+	if errcode == codes.Canceled || errcode == codes.OK {
 		err = nil
 	}
 	span.SetTag(tagCode, errcode.String())

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/server.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc/server.go
@@ -28,7 +28,7 @@ func (ss *serverStream) Context() context.Context {
 func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer finishWithError(span, err, ss.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
 	}
 	err = ss.ServerStream.RecvMsg(m)
 	return err
@@ -37,7 +37,7 @@ func (ss *serverStream) RecvMsg(m interface{}) (err error) {
 func (ss *serverStream) SendMsg(m interface{}) (err error) {
 	if ss.cfg.traceStreamMessages {
 		span, _ := startSpanFromContext(ss.ctx, ss.method, "grpc.message", ss.cfg.serverServiceName())
-		defer finishWithError(span, err, ss.cfg.noDebugStack)
+		defer func() { finishWithError(span, err, ss.cfg.noDebugStack) }()
 	}
 	err = ss.ServerStream.SendMsg(m)
 	return err
@@ -60,7 +60,7 @@ func StreamServerInterceptor(opts ...InterceptorOption) grpc.StreamServerInterce
 		if cfg.traceStreamCalls {
 			var span ddtrace.Span
 			span, ctx = startSpanFromContext(ctx, info.FullMethod, "grpc.server", cfg.serviceName)
-			defer finishWithError(span, err, cfg.noDebugStack)
+			defer func() { finishWithError(span, err, cfg.noDebugStack) }()
 		}
 
 		// call the original handler with a new stream, which traces each send

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/mongodb/mongo-go-driver/mongo/mongo.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/mongodb/mongo-go-driver/mongo/mongo.go
@@ -1,4 +1,5 @@
 // Package mongo provides functions to trace the mongodb/mongo-go-driver package (https://github.com/mongodb/mongo-go-driver).
+// It support v0.2.0 of github.com/mongodb/mongo-go-driver
 //
 // `NewMonitor` will return an event.CommandMonitor which is used to trace requests.
 package mongo

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/contrib/mongodb/mongo-go-driver/mongo/mongo_test.go
@@ -60,7 +60,7 @@ func Test(t *testing.T) {
 	assert.Equal(t, "mongo.insert", s.Tag(ext.ResourceName))
 	assert.Equal(t, hostname, s.Tag(ext.PeerHostname))
 	assert.Equal(t, port, s.Tag(ext.PeerPort))
-	assert.Contains(t, s.Tag(ext.DBStatement), `{"insert":"test-collection","ordered":true,"$db":"test-database","documents":[{"_id":{"`)
+	assert.Contains(t, s.Tag(ext.DBStatement), `"test-item":"test-value"`)
 	assert.Equal(t, "test-database", s.Tag(ext.DBInstance))
 	assert.Equal(t, "mongo", s.Tag(ext.DBType))
 }

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ddtrace.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ddtrace.go
@@ -108,4 +108,8 @@ type StartSpanConfig struct {
 	// Tags holds a set of key/value pairs that should be set as metadata on the
 	// new span.
 	Tags map[string]interface{}
+
+	// Force-set the SpanID, rather than use a random number. If no Parent SpanContext is present,
+	// then this will also set the TraceID to the same value.
+	SpanID uint64
 }

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/option.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/option.go
@@ -149,6 +149,15 @@ func SpanType(name string) StartSpanOption {
 	return Tag(ext.SpanType, name)
 }
 
+// WithSpanID sets the SpanID on the started span, instead of using a random number.
+// If there is no parent Span (eg from ChildOf), then the TraceID will also be set to the
+// value given here.
+func WithSpanID(id uint64) StartSpanOption {
+	return func(cfg *ddtrace.StartSpanConfig) {
+		cfg.SpanID = id
+	}
+}
+
 // ChildOf tells StartSpan to use the given span context as a parent for the
 // created span.
 func ChildOf(ctx ddtrace.SpanContext) StartSpanOption {
@@ -179,7 +188,8 @@ func FinishTime(t time.Time) FinishOption {
 }
 
 // WithError marks the span as having had an error. It uses the information from
-// err to set tags such as the error message, error type and stack trace.
+// err to set tags such as the error message, error type and stack trace. It has
+// no effect if the error is nil.
 func WithError(err error) FinishOption {
 	return func(cfg *ddtrace.FinishConfig) {
 		cfg.Error = err

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler.go
@@ -140,5 +140,5 @@ func (ps *prioritySampler) apply(spn *span) {
 	} else {
 		spn.SetTag(ext.SamplingPriority, ext.PriorityAutoReject)
 	}
-	spn.SetTag(samplingPriorityRateKey, rate)
+	spn.SetTag(keySamplingPriorityRate, rate)
 }

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/sampler_test.go
@@ -144,18 +144,18 @@ func TestPrioritySampler(t *testing.T) {
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 4)
 
 		ps.apply(testSpan1)
-		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 3)
 		ps.apply(testSpan1)
-		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 
 		testSpan1.Service = "other-service"
 		testSpan1.TraceID = 1
-		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 	})
 }
 

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span.go
@@ -150,7 +150,7 @@ func (s *span) setTagNumeric(key string, v float64) {
 	switch key {
 	case ext.SamplingPriority:
 		// setting sampling priority per spec
-		s.Metrics[samplingPriorityKey] = v
+		s.Metrics[keySamplingPriority] = v
 		s.context.setSamplingPriority(int(v))
 	default:
 		s.Metrics[key] = v
@@ -236,6 +236,7 @@ func (s *span) String() string {
 }
 
 const (
-	samplingPriorityKey     = "_sampling_priority_v1"
-	samplingPriorityRateKey = "_sampling_priority_rate_v1"
+	keySamplingPriority     = "_sampling_priority_v1"
+	keySamplingPriorityRate = "_sampling_priority_rate_v1"
+	keyOrigin               = "_dd.origin"
 )

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/span_test.go
@@ -160,7 +160,7 @@ func TestSpanSetTag(t *testing.T) {
 	assert.Equal(int32(0), span.Error)
 
 	span.SetTag(ext.SamplingPriority, 2)
-	assert.Equal(float64(2), span.Metrics[samplingPriorityKey])
+	assert.Equal(float64(2), span.Metrics[keySamplingPriority])
 }
 
 func TestSpanSetDatadogTags(t *testing.T) {
@@ -204,9 +204,9 @@ func TestSpanSetMetric(t *testing.T) {
 	span.SetTag("bytes", 1024.42)
 	assert.Equal(3, len(span.Metrics))
 	assert.Equal(1024.42, span.Metrics["bytes"])
-	_, ok := span.Metrics[samplingPriorityKey]
+	_, ok := span.Metrics[keySamplingPriority]
 	assert.True(ok)
-	_, ok = span.Metrics[samplingPriorityRateKey]
+	_, ok = span.Metrics[keySamplingPriorityRate]
 	assert.True(ok)
 
 	// operating on a finished span is a no-op
@@ -301,9 +301,9 @@ func TestSpanSamplingPriority(t *testing.T) {
 	tracer := newTracer(withTransport(newDefaultTransport()))
 
 	span := tracer.newRootSpan("my.name", "my.service", "my.resource")
-	_, ok := span.Metrics[samplingPriorityKey]
+	_, ok := span.Metrics[keySamplingPriority]
 	assert.True(ok)
-	_, ok = span.Metrics[samplingPriorityRateKey]
+	_, ok = span.Metrics[keySamplingPriorityRate]
 	assert.True(ok)
 
 	for _, priority := range []int{
@@ -314,15 +314,15 @@ func TestSpanSamplingPriority(t *testing.T) {
 		999, // not used, but we should allow it
 	} {
 		span.SetTag(ext.SamplingPriority, priority)
-		v, ok := span.Metrics[samplingPriorityKey]
+		v, ok := span.Metrics[keySamplingPriority]
 		assert.True(ok)
 		assert.EqualValues(priority, v)
 		assert.EqualValues(span.context.priority, v)
 		assert.True(span.context.hasPriority)
 
 		childSpan := tracer.newChildSpan("my.child", span)
-		v0, ok0 := span.Metrics[samplingPriorityKey]
-		v1, ok1 := childSpan.Metrics[samplingPriorityKey]
+		v0, ok0 := span.Metrics[keySamplingPriority]
+		v1, ok1 := childSpan.Metrics[keySamplingPriority]
 		assert.Equal(ok0, ok1)
 		assert.Equal(v0, v1)
 		assert.EqualValues(childSpan.context.priority, v0)

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/spancontext.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/spancontext.go
@@ -28,6 +28,7 @@ type spanContext struct {
 	mu          sync.RWMutex // guards below fields
 	baggage     map[string]string
 	priority    int
+	origin      string // e.g. "synthetics"
 	hasPriority bool
 }
 
@@ -42,7 +43,7 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 		spanID:  span.SpanID,
 		span:    span,
 	}
-	if v, ok := span.Metrics[samplingPriorityKey]; ok {
+	if v, ok := span.Metrics[keySamplingPriority]; ok {
 		context.hasPriority = true
 		context.priority = int(v)
 	}
@@ -51,6 +52,7 @@ func newSpanContext(span *span, parent *spanContext) *spanContext {
 		context.drop = parent.drop
 		context.hasPriority = parent.hasSamplingPriority()
 		context.priority = parent.samplingPriority()
+		context.origin = parent.origin
 		parent.ForeachBaggageItem(func(k, v string) bool {
 			context.setBaggageItem(k, v)
 			return true

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/spancontext_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/spancontext_test.go
@@ -171,7 +171,7 @@ func TestNewSpanContext(t *testing.T) {
 			TraceID:  1,
 			SpanID:   2,
 			ParentID: 3,
-			Metrics:  map[string]float64{samplingPriorityKey: 1},
+			Metrics:  map[string]float64{keySamplingPriority: 1},
 		}
 		ctx := newSpanContext(span, nil)
 		assert := assert.New(t)
@@ -207,6 +207,10 @@ func TestSpanContextParent(t *testing.T) {
 			hasPriority: true,
 			priority:    2,
 		},
+		"origin": &spanContext{
+			trace:  &trace{spans: []*span{newBasicSpan("abc")}},
+			origin: "synthetics",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			ctx := newSpanContext(s, parentCtx)
@@ -222,6 +226,7 @@ func TestSpanContextParent(t *testing.T) {
 			assert.Equal(ctx.priority, parentCtx.priority)
 			assert.Equal(ctx.drop, parentCtx.drop)
 			assert.Equal(ctx.baggage, parentCtx.baggage)
+			assert.Equal(ctx.origin, parentCtx.origin)
 		})
 	}
 }

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/tracer.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/tracer.go
@@ -230,7 +230,10 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 			context = ctx
 		}
 	}
-	id := random.Uint64()
+	id := opts.SpanID
+	if id == 0 {
+		id = random.Uint64()
+	}
 	// span defaults
 	span := &span{
 		Name:     operationName,
@@ -248,13 +251,19 @@ func (t *tracer) StartSpan(operationName string, options ...ddtrace.StartSpanOpt
 		span.TraceID = context.traceID
 		span.ParentID = context.spanID
 		if context.hasSamplingPriority() {
-			span.Metrics[samplingPriorityKey] = float64(context.samplingPriority())
+			span.Metrics[keySamplingPriority] = float64(context.samplingPriority())
 		}
 		if context.span != nil {
-			// it has a local parent, inherit the service
+			// local parent, inherit service
 			context.span.RLock()
 			span.Service = context.span.Service
 			context.span.RUnlock()
+		} else {
+			// remote parent
+			if context.origin != "" {
+				// mark origin
+				span.Meta[keyOrigin] = context.origin
+			}
 		}
 	}
 	span.context = newSpanContext(span, context)

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/tracer_test.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/tracer_test.go
@@ -165,13 +165,13 @@ func TestTracerStartSpan(t *testing.T) {
 		assert.Contains([]float64{
 			ext.PriorityAutoReject,
 			ext.PriorityAutoKeep,
-		}, span.Metrics[samplingPriorityKey])
+		}, span.Metrics[keySamplingPriority])
 	})
 
 	t.Run("priority", func(t *testing.T) {
 		tracer := newTracer()
 		span := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, ext.PriorityUserKeep)).(*span)
-		assert.Equal(t, float64(ext.PriorityUserKeep), span.Metrics[samplingPriorityKey])
+		assert.Equal(t, float64(ext.PriorityUserKeep), span.Metrics[keySamplingPriority])
 	})
 }
 
@@ -183,6 +183,7 @@ func TestTracerStartSpanOptions(t *testing.T) {
 		ServiceName("test.service"),
 		ResourceName("test.resource"),
 		StartTime(now),
+		WithSpanID(420),
 	}
 	span := tracer.StartSpan("web.request", opts...).(*span)
 	assert := assert.New(t)
@@ -190,6 +191,8 @@ func TestTracerStartSpanOptions(t *testing.T) {
 	assert.Equal("test.service", span.Service)
 	assert.Equal("test.resource", span.Resource)
 	assert.Equal(now.UnixNano(), span.Start)
+	assert.Equal(uint64(420), span.SpanID)
+	assert.Equal(uint64(420), span.TraceID)
 }
 
 func TestTracerStartChildSpan(t *testing.T) {
@@ -197,12 +200,17 @@ func TestTracerStartChildSpan(t *testing.T) {
 		assert := assert.New(t)
 		tracer := newTracer()
 		root := tracer.StartSpan("web.request", ServiceName("root-service")).(*span)
-		child := tracer.StartSpan("db.query", ChildOf(root.Context()), ServiceName("child-service")).(*span)
+		child := tracer.StartSpan("db.query",
+			ChildOf(root.Context()),
+			ServiceName("child-service"),
+			WithSpanID(69)).(*span)
 
 		assert.NotEqual(uint64(0), child.TraceID)
 		assert.NotEqual(uint64(0), child.SpanID)
 		assert.Equal(root.SpanID, child.ParentID)
 		assert.Equal(root.TraceID, child.ParentID)
+		assert.Equal(root.TraceID, child.TraceID)
+		assert.Equal(uint64(69), child.SpanID)
 		assert.Equal("child-service", child.Service)
 	})
 
@@ -225,6 +233,34 @@ func TestTracerBaggagePropagation(t *testing.T) {
 	context := child.Context().(*spanContext)
 
 	assert.Equal("value", context.baggage["key"])
+}
+
+func TestStartSpanOrigin(t *testing.T) {
+	assert := assert.New(t)
+
+	tracer := newTracer()
+
+	carrier := TextMapCarrier(map[string]string{
+		DefaultTraceIDHeader:  "1",
+		DefaultParentIDHeader: "1",
+		originHeader:          "synthetics",
+	})
+	ctx, err := tracer.Extract(carrier)
+	assert.Nil(err)
+
+	// first child contains tag
+	child := tracer.StartSpan("child", ChildOf(ctx))
+	assert.Equal("synthetics", child.(*span).Meta[keyOrigin])
+
+	// secondary child doesn't
+	child2 := tracer.StartSpan("child2", ChildOf(child.Context()))
+	assert.Empty(child2.(*span).Meta[keyOrigin])
+
+	// but injecting its context marks origin
+	carrier2 := TextMapCarrier(map[string]string{})
+	err = tracer.Inject(child2.Context(), carrier2)
+	assert.Nil(err)
+	assert.Equal("synthetics", carrier2[originHeader])
 }
 
 func TestPropagationDefaults(t *testing.T) {
@@ -278,8 +314,8 @@ func TestTracerSamplingPriorityPropagation(t *testing.T) {
 	tracer := newTracer()
 	root := tracer.StartSpan("web.request", Tag(ext.SamplingPriority, 2)).(*span)
 	child := tracer.StartSpan("db.query", ChildOf(root.Context())).(*span)
-	assert.EqualValues(2, root.Metrics[samplingPriorityKey])
-	assert.EqualValues(2, child.Metrics[samplingPriorityKey])
+	assert.EqualValues(2, root.Metrics[keySamplingPriority])
+	assert.EqualValues(2, child.Metrics[keySamplingPriority])
 	assert.EqualValues(2, root.context.priority)
 	assert.EqualValues(2, child.context.priority)
 	assert.True(root.context.hasPriority)
@@ -403,10 +439,10 @@ func TestTracerPrioritySampler(t *testing.T) {
 
 	// default rates (1.0)
 	s := tr.newEnvSpan("pylons", "")
-	assert.Equal(1., s.Metrics[samplingPriorityRateKey])
-	assert.Equal(1., s.Metrics[samplingPriorityKey])
+	assert.Equal(1., s.Metrics[keySamplingPriorityRate])
+	assert.Equal(1., s.Metrics[keySamplingPriority])
 	assert.True(s.context.hasSamplingPriority())
-	assert.EqualValues(s.context.samplingPriority(), s.Metrics[samplingPriorityKey])
+	assert.EqualValues(s.context.samplingPriority(), s.Metrics[keySamplingPriority])
 	s.Finish()
 
 	tr.forceFlush() // obtain new rates
@@ -435,8 +471,8 @@ func TestTracerPrioritySampler(t *testing.T) {
 		},
 	} {
 		s := tr.newEnvSpan(tt.service, tt.env)
-		assert.Equal(tt.rate, s.Metrics[samplingPriorityRateKey], strconv.Itoa(i))
-		prio, ok := s.Metrics[samplingPriorityKey]
+		assert.Equal(tt.rate, s.Metrics[keySamplingPriorityRate], strconv.Itoa(i))
+		prio, ok := s.Metrics[keySamplingPriority]
 		assert.True(ok)
 		assert.Contains([]float64{0, 1}, prio)
 		assert.True(s.context.hasSamplingPriority())

--- a/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/transport.go
+++ b/vendor/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer/transport.go
@@ -15,7 +15,7 @@ import (
 var (
 	// TODO(gbbr): find a more effective way to keep this up to date,
 	// e.g. via `go generate`
-	tracerVersion = "v1.7.0"
+	tracerVersion = "v1.10.0"
 
 	// We copy the transport to avoid using the default one, as it might be
 	// augmented with tracing and we don't want these calls to be recorded.


### PR DESCRIPTION
**Summary**

1st Commit: I cleaned up some minor issues that were found in a previous PR.
2nd Commit: Updated the datadog apm go package
3rd Commit: Removed the deferred function calls for finishing the spans.

The 3rd commit is the only one really required to fix the issue.

The issue was due to gotcha number 3 in this article
https://blog.learngoprogramming.com/5-gotchas-of-defer-in-go-golang-part-ii-cc550f6ad9aa

> Params passed to a deferred func are evaluated when the defer is registered not when it runs


Here is a screenshot from a failed spawn
![screen shot 2019-03-07 at 9 15 49 am](https://user-images.githubusercontent.com/29802892/53975481-c7fec200-40b9-11e9-8508-cb11f5d3e865.png)

Here is a screenshot from a successful spawn
![screen shot 2019-03-07 at 9 21 11 am](https://user-images.githubusercontent.com/29802892/53975739-69861380-40ba-11e9-8f4b-37aa29e5d9d1.png)
