### PR TITLE
istio: add istio-injection label to nitro created namespaces

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -40,6 +40,7 @@ var k8sMaxage, destroyedenvsMaxage, eventlogsMaxage time.Duration
 func init() {
 	cleanupCmd.Flags().DurationVar(&k8sMaxage, "k8s-objs-max-age", 14*24*time.Hour, "Maximum age for orphaned k8s objects")
 	cleanupCmd.Flags().DurationVar(&destroyedenvsMaxage, "destroyed-envs-max-age", 30*24*time.Hour, "Maximum age for destroyed environment DB records")
+	cleanupCmd.Flags().DurationVar(&eventlogsMaxage, "event-logs-max-age", 30*24*time.Hour, "Maximum age for event log DB records")
 	RootCmd.AddCommand(cleanupCmd)
 }
 

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -40,7 +40,6 @@ var k8sMaxage, destroyedenvsMaxage, eventlogsMaxage time.Duration
 func init() {
 	cleanupCmd.Flags().DurationVar(&k8sMaxage, "k8s-objs-max-age", 14*24*time.Hour, "Maximum age for orphaned k8s objects")
 	cleanupCmd.Flags().DurationVar(&destroyedenvsMaxage, "destroyed-envs-max-age", 30*24*time.Hour, "Maximum age for destroyed environment DB records")
-	cleanupCmd.PersistentFlags().StringVar(&k8sLabelsStr, "k8s-labels", "acyl.dev/managed-by=nitro,istio-injection=enabled", "comma-separated list of key/value pairs in the form <key1>=<value1>,<key2>=<value2>. Note: The combination of labels should be unique in the cluster")
 	RootCmd.AddCommand(cleanupCmd)
 }
 
@@ -76,8 +75,6 @@ func cleanup(cmd *cobra.Command, args []string) {
 	}
 
 	cleaner.Clean()
-	// Todo: Looks like we may want to process the other k8sConfig values as well
-	err = k8sConfig.ProcessLabels(k8sLabelsStr)
 	if err != nil {
 		log.Fatalf("error in k8s labels: %v", err)
 	}

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -79,7 +79,16 @@ func cleanup(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("error in k8s labels: %v", err)
 	}
-	ci, err := metahelm.NewChartInstaller(nil, dl, nil, nil, k8sConfig.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, k8sConfig.SecretInjections, metahelm.TillerConfig{}, k8sClientConfig.JWTPath, true, k8sConfig.Labels)
+	ci, err := metahelm.NewChartInstaller(metahelm.ChartInstallerConfig{
+		DataLayer:           dl,
+		K8sGroupBindings:    k8sConfig.GroupBindings,
+		K8sRepoWhiteList:    k8sConfig.PrivilegedRepoWhitelist,
+		K8sSecretInjections: k8sConfig.SecretInjections,
+		K8sLabels:           k8sConfig.Labels,
+		TillerConfig:        metahelm.TillerConfig{},
+		K8sJWTPath:          k8sClientConfig.JWTPath,
+		EnableK8sTracing:    true,
+	})
 	if err != nil {
 		log.Fatalf("error getting metahelm chart installer: %v", err)
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,7 +51,7 @@ var configInfoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "get summary information from an acyl.yml",
 	Long: `Parses, validates and displays summary information about the acyl.yml in the current directory
-(which must be a valid git repo with GitHub remotes). Branch matching will use the currently checked-out branch and the value 
+(which must be a valid git repo with GitHub remotes). Branch matching will use the currently checked-out branch and the value
 passed in for the base-branch flag.
 
 Paths provided by --search-paths will be recursively searched for valid git repositories containing GitHub remotes,
@@ -231,7 +231,7 @@ func configCheck(cmd *cobra.Command, args []string) {
 		perr("error fetching charts: %v", err)
 		return
 	}
-	ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil)
+	ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil, nil)
 	if err != nil {
 		perr("error creating chart installer: %v", err)
 		return
@@ -759,7 +759,7 @@ func displayInfoTerminal(rc *models.RepoConfig, err error, mg meta.Getter) int {
 			errorModal("Error Processing Charts", "Check your chart configuration.", err)
 			return
 		}
-		ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil)
+		ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil, nil)
 		if err != nil {
 			errorModal("Error Instantiating Chart Installer", "Bug!", err)
 			return

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -231,7 +231,10 @@ func configCheck(cmd *cobra.Command, args []string) {
 		perr("error fetching charts: %v", err)
 		return
 	}
-	ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil, nil)
+	ci, err := metahelm.NewChartInstallerWithoutK8sClient(metahelm.ChartInstallerConfig{
+		Filesystem:       osfs.New(""),
+		MetricsCollector: &metrics.FakeCollector{},
+	})
 	if err != nil {
 		perr("error creating chart installer: %v", err)
 		return
@@ -759,7 +762,10 @@ func displayInfoTerminal(rc *models.RepoConfig, err error, mg meta.Getter) int {
 			errorModal("Error Processing Charts", "Check your chart configuration.", err)
 			return
 		}
-		ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil, nil)
+		ci, err := metahelm.NewChartInstallerWithoutK8sClient(metahelm.ChartInstallerConfig{
+			Filesystem:       osfs.New(""),
+			MetricsCollector: &metrics.FakeCollector{},
+		})
 		if err != nil {
 			errorModal("Error Instantiating Chart Installer", "Bug!", err)
 			return

--- a/cmd/integration.go
+++ b/cmd/integration.go
@@ -46,7 +46,6 @@ func init() {
 	integrationCmd.Flags().StringVar(&integrationcfg.dataFile, "data-file", "testdata/integration/data.json", "path to JSON data file")
 	integrationCmd.Flags().StringVar(&integrationcfg.webhookFile, "webhook-file", "testdata/integration/webhook.json", "path to JSON webhook file")
 	integrationCmd.Flags().StringVar(&integrationcfg.githubToken, "github-token", os.Getenv("GITHUB_TOKEN"), "GitHub access token")
-	integrationCmd.PersistentFlags().StringVar(&k8sLabelsStr, "k8s-labels", "acyl.dev/managed-by=nitro,istio-injection=enabled", "comma-separated list of key/value pairs in the form <key1>=<value1>,<key2>=<value2>. Note: The combination of labels should be unique in the cluster")
 	RootCmd.AddCommand(integrationCmd)
 }
 
@@ -166,10 +165,6 @@ func setupNitro(dl persistence.DataLayer) (spawner.EnvironmentSpawner, ghclient.
 	fs := osfs.New("")
 	mg := &meta.DataGetter{RC: rc, FS: fs}
 	ib := &images.FakeImageBuilder{BatchCompletedFunc: func(envname, repo string) (bool, error) { return true, nil }}
-	err := k8sConfig.ProcessLabels(k8sLabelsStr)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "error in k8s labels")
-	}
 	ci, err := metahelm.NewChartInstaller(ib, dl, fs, mc, map[string]string{}, []string{}, map[string]config.K8sSecret{}, metahelm.TillerConfig{}, k8sClientConfig.JWTPath, false, k8sConfig.Labels)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error getting metahelm chart installer")

--- a/cmd/integration.go
+++ b/cmd/integration.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/dollarshaveclub/acyl/pkg/config"
 	"github.com/dollarshaveclub/acyl/pkg/ghclient"
 	"github.com/dollarshaveclub/acyl/pkg/ghevent"
 	"github.com/dollarshaveclub/acyl/pkg/locker"
@@ -165,7 +164,15 @@ func setupNitro(dl persistence.DataLayer) (spawner.EnvironmentSpawner, ghclient.
 	fs := osfs.New("")
 	mg := &meta.DataGetter{RC: rc, FS: fs}
 	ib := &images.FakeImageBuilder{BatchCompletedFunc: func(envname, repo string) (bool, error) { return true, nil }}
-	ci, err := metahelm.NewChartInstaller(ib, dl, fs, mc, map[string]string{}, []string{}, map[string]config.K8sSecret{}, metahelm.TillerConfig{}, k8sClientConfig.JWTPath, false, k8sConfig.Labels)
+	ci, err := metahelm.NewChartInstaller(metahelm.ChartInstallerConfig{
+		ImageBuilder:     ib,
+		DataLayer:        dl,
+		Filesystem:       fs,
+		MetricsCollector: mc,
+		TillerConfig:     metahelm.TillerConfig{},
+		K8sJWTPath:       k8sClientConfig.JWTPath,
+		K8sLabels:        k8sConfig.Labels,
+	})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error getting metahelm chart installer")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,11 +18,17 @@ var awsConfig config.AWSConfig
 var secretsConfig config.SecretsConfig
 var secretsbackend string
 var k8sClientConfig config.K8sClientConfig
+var k8sLabelsStr string
 
 var RootCmd = &cobra.Command{
 	Use:   "acyl",
 	Short: "Dynamic Environment System",
 	Long:  `Dynamic environment server API and client utility`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := k8sConfig.ProcessLabels(k8sLabelsStr); err != nil {
+			clierr("error in k8s labels: %v", err)
+		}
+	},
 }
 
 //shorthands in use by register: i p r m o
@@ -42,6 +48,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&secretsbackend, "secrets-backend", "vault", "Secret backend (one of: vault,env)")
 	RootCmd.PersistentFlags().StringVar(&secretsConfig.Mapping, "secrets-mapping", "", "Secrets mapping template string (required)")
 	RootCmd.PersistentFlags().StringVar(&k8sClientConfig.JWTPath, "k8s-jwt-path", "/var/run/secrets/kubernetes.io/serviceaccount/token", "Path to the JWT used to authenticate the k8s client to the API server")
+	RootCmd.PersistentFlags().StringVar(&k8sLabelsStr, "k8s-labels", "acyl.dev/managed-by=nitro", "comma-separated list of key/value pairs in the form <key1>=<value1>,<key2>=<value2>. Note: The combination of labels should be unique in the cluster")
 }
 
 func clierr(msg string, params ...interface{}) {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -51,7 +51,7 @@ var backendConfig config.BackendConfig
 var aminoConfig config.AminoConfig
 
 var k8sConfig config.K8sConfig
-var k8sGroupBindingsStr, k8sSecretsStr, k8sPrivilegedReposStr, k8sLabelsStr string
+var k8sGroupBindingsStr, k8sSecretsStr, k8sPrivilegedReposStr string
 
 var pgConfig config.PGConfig
 var logger *log.Logger
@@ -105,7 +105,6 @@ func init() {
 	serverCmd.PersistentFlags().StringVar(&k8sGroupBindingsStr, "k8s-group-bindings", "", "optional k8s RBAC group bindings (comma-separated) for new environment namespaces in GROUP1=CLUSTER_ROLE1,GROUP2=CLUSTER_ROLE2 format (ex: users=edit) (Nitro)")
 	serverCmd.PersistentFlags().StringVar(&k8sSecretsStr, "k8s-secret-injections", "", "optional k8s secret injections (comma-separated) for new environment namespaces in SECRET_NAME=VAULT_ID (Vault path using secrets mapping) format. Secret value in Vault must be a JSON-encoded object with two keys: 'data' (map of string to base64-encoded bytes), 'type' (string). (Nitro)")
 	serverCmd.PersistentFlags().StringVar(&k8sPrivilegedReposStr, "k8s-privileged-repo-whitelist", "dollarshaveclub/acyl", "optional comma-separated whitelist of GitHub repositories whose environment service accounts will be allowed cluster-admin privileges (Nitro)")
-	serverCmd.PersistentFlags().StringVar(&k8sLabelsStr, "k8s-labels", "acyl.dev/managed-by=nitro,istio-injection=enabled", "comma-separated list of key/value pairs in the form <key1>=<value1>,<key2>=<value2>. Note: The combination of labels should be unique in the cluster")
 	serverCmd.PersistentFlags().StringVar(&failureTemplatePath, "failure-template-path", "/opt/html/failedenv.html.tmpl", "path to HTML failure report template (if missing, failure reports will be disabled")
 	serverCmd.PersistentFlags().StringVar(&s3config.Region, "failure-report-s3-region", "us-west-2", "AWS S3 region for environment failure reports")
 	serverCmd.PersistentFlags().StringVar(&s3config.Bucket, "failure-report-s3-bucket", "", "AWS S3 bucket for environment failure reports")
@@ -211,9 +210,6 @@ func server(cmd *cobra.Command, args []string) {
 		}
 		if err := k8sConfig.ProcessGroupBindings(k8sGroupBindingsStr); err != nil {
 			log.Fatalf("error in k8s group bindings: %v", err)
-		}
-		if err := k8sConfig.ProcessLabels(k8sLabelsStr); err != nil {
-			log.Fatalf("error in k8s labels: %v", err)
 		}
 		sc, err := getSecretClient()
 		if err != nil {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -218,7 +218,18 @@ func server(cmd *cobra.Command, args []string) {
 		if err := k8sConfig.ProcessSecretInjections(sc, k8sSecretsStr); err != nil {
 			log.Fatalf("error in k8s secret injections: %v", err)
 		}
-		ci, err := metahelm.NewChartInstaller(ib, dl, fs, nmc, k8sConfig.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, k8sConfig.SecretInjections, metahelm.TillerConfig{}, k8sClientConfig.JWTPath, true, k8sConfig.Labels)
+		ci, err := metahelm.NewChartInstaller(metahelm.ChartInstallerConfig{
+			ImageBuilder:        ib,
+			DataLayer:           dl,
+			Filesystem:          fs,
+			K8sGroupBindings:    k8sConfig.GroupBindings,
+			K8sRepoWhiteList:    k8sConfig.PrivilegedRepoWhitelist,
+			K8sSecretInjections: k8sConfig.SecretInjections,
+			TillerConfig:        metahelm.TillerConfig{},
+			K8sJWTPath:          k8sClientConfig.JWTPath,
+			EnableK8sTracing:    true,
+			K8sLabels:           k8sConfig.Labels,
+		})
 		if err != nil {
 			log.Fatalf("error getting metahelm chart installer: %v", err)
 		}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -51,7 +51,7 @@ var backendConfig config.BackendConfig
 var aminoConfig config.AminoConfig
 
 var k8sConfig config.K8sConfig
-var k8sGroupBindingsStr, k8sSecretsStr, k8sPrivilegedReposStr string
+var k8sGroupBindingsStr, k8sSecretsStr, k8sPrivilegedReposStr, k8sLabelsStr string
 
 var pgConfig config.PGConfig
 var logger *log.Logger
@@ -105,6 +105,7 @@ func init() {
 	serverCmd.PersistentFlags().StringVar(&k8sGroupBindingsStr, "k8s-group-bindings", "", "optional k8s RBAC group bindings (comma-separated) for new environment namespaces in GROUP1=CLUSTER_ROLE1,GROUP2=CLUSTER_ROLE2 format (ex: users=edit) (Nitro)")
 	serverCmd.PersistentFlags().StringVar(&k8sSecretsStr, "k8s-secret-injections", "", "optional k8s secret injections (comma-separated) for new environment namespaces in SECRET_NAME=VAULT_ID (Vault path using secrets mapping) format. Secret value in Vault must be a JSON-encoded object with two keys: 'data' (map of string to base64-encoded bytes), 'type' (string). (Nitro)")
 	serverCmd.PersistentFlags().StringVar(&k8sPrivilegedReposStr, "k8s-privileged-repo-whitelist", "dollarshaveclub/acyl", "optional comma-separated whitelist of GitHub repositories whose environment service accounts will be allowed cluster-admin privileges (Nitro)")
+	serverCmd.PersistentFlags().StringVar(&k8sLabelsStr, "k8s-labels", "acyl.dev/managed-by=nitro,istio-injection=enabled", "comma-separated list of key/value pairs in the form <key1>=<value1>,<key2>=<value2>. Note: The combination of labels should be unique in the cluster")
 	serverCmd.PersistentFlags().StringVar(&failureTemplatePath, "failure-template-path", "/opt/html/failedenv.html.tmpl", "path to HTML failure report template (if missing, failure reports will be disabled")
 	serverCmd.PersistentFlags().StringVar(&s3config.Region, "failure-report-s3-region", "us-west-2", "AWS S3 region for environment failure reports")
 	serverCmd.PersistentFlags().StringVar(&s3config.Bucket, "failure-report-s3-bucket", "", "AWS S3 bucket for environment failure reports")
@@ -211,6 +212,9 @@ func server(cmd *cobra.Command, args []string) {
 		if err := k8sConfig.ProcessGroupBindings(k8sGroupBindingsStr); err != nil {
 			log.Fatalf("error in k8s group bindings: %v", err)
 		}
+		if err := k8sConfig.ProcessLabels(k8sLabelsStr); err != nil {
+			log.Fatalf("error in k8s labels: %v", err)
+		}
 		sc, err := getSecretClient()
 		if err != nil {
 			log.Fatalf("error getting secrets client: %v", err)
@@ -218,7 +222,7 @@ func server(cmd *cobra.Command, args []string) {
 		if err := k8sConfig.ProcessSecretInjections(sc, k8sSecretsStr); err != nil {
 			log.Fatalf("error in k8s secret injections: %v", err)
 		}
-		ci, err := metahelm.NewChartInstaller(ib, dl, fs, nmc, k8sConfig.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, k8sConfig.SecretInjections, metahelm.TillerConfig{}, k8sClientConfig.JWTPath, true)
+		ci, err := metahelm.NewChartInstaller(ib, dl, fs, nmc, k8sConfig.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, k8sConfig.SecretInjections, metahelm.TillerConfig{}, k8sClientConfig.JWTPath, true, k8sConfig.Labels)
 		if err != nil {
 			log.Fatalf("error getting metahelm chart installer: %v", err)
 		}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -359,7 +359,17 @@ func testConfigSetup() (*nitroenv.Manager, context.Context, *models.RepoRevision
 		ServerConnectRetries:    10,
 		ServerConnectRetryDelay: 2 * time.Second,
 	}
-	ci, err := metahelm.NewChartInstallerWithClientsetFromContext(ib, dl, fs, mc, testEnvCfg.k8sCfg.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, testEnvCfg.k8sCfg.SecretInjections, tcfg, testEnvCfg.kubeCfgPath, testEnvCfg.kubeCtx, testEnvCfg.k8sCfg.Labels)
+	ci, err := metahelm.NewChartInstallerWithClientsetFromContext(metahelm.ChartInstallerConfig{
+		ImageBuilder:        ib,
+		DataLayer:           dl,
+		Filesystem:          fs,
+		MetricsCollector:    mc,
+		K8sGroupBindings:    testEnvCfg.k8sCfg.GroupBindings,
+		K8sRepoWhiteList:    k8sConfig.PrivilegedRepoWhitelist, // TODO: Should this be using testEnvCfg? Left as is to maintain current behavior
+		K8sSecretInjections: testEnvCfg.k8sCfg.SecretInjections,
+		TillerConfig:        tcfg,
+		K8sLabels:           testEnvCfg.k8sCfg.Labels,
+	}, testEnvCfg.kubeCfgPath, testEnvCfg.kubeCtx)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error getting chart installer")
 	}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -121,7 +121,7 @@ func init() {
 	configTestCmd.PersistentFlags().BoolVar(&testEnvCfg.privileged, "privileged", false, "give the environment service account ClusterAdmin privileges via a ClusterRoleBinding (use this if your application requires ClusterAdmin abilities)")
 	configTestCmd.PersistentFlags().StringVar(&k8sGroupBindingsStr, "k8s-group-bindings", "", "optional k8s RBAC group bindings for the environment namespace (comma-separated) in GROUP1=CLUSTER_ROLE1,GROUP2=CLUSTER_ROLE2 format (ex: users=edit)")
 	configTestCmd.PersistentFlags().StringVar(&k8sSecretsStr, "k8s-secret-injections", "", "optional k8s secret injections (comma-separated) for new environment namespaces (other than image-pull-secret) in SECRET_NAME=VAULT_ID (Vault path using secrets mapping) format. Secret value in Vault must be a JSON-encoded object with two keys: 'data' (map of string to base64-encoded bytes), 'type' (string).")
-	configTestCmd.PersistentFlags().StringVar(&k8sLabelsStr, "k8s-labels", "acyl.dev/managed-by=nitro,istio-injection=enabled", "comma-separated list of key/value pairs in the form <key1>=<value1>,<key2>=<value2>. Note: The combination of labels should be unique in the cluster")
+	configTestCmd.PersistentFlags().StringVar(&k8sLabelsStr, "k8s-labels", "acyl.dev/managed-by=nitro", "comma-separated list of key/value pairs in the form <key1>=<value1>,<key2>=<value2>. Note: The combination of labels should be unique in the cluster")
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Printf("error getting working directory: %v", err)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -121,6 +121,7 @@ func init() {
 	configTestCmd.PersistentFlags().BoolVar(&testEnvCfg.privileged, "privileged", false, "give the environment service account ClusterAdmin privileges via a ClusterRoleBinding (use this if your application requires ClusterAdmin abilities)")
 	configTestCmd.PersistentFlags().StringVar(&k8sGroupBindingsStr, "k8s-group-bindings", "", "optional k8s RBAC group bindings for the environment namespace (comma-separated) in GROUP1=CLUSTER_ROLE1,GROUP2=CLUSTER_ROLE2 format (ex: users=edit)")
 	configTestCmd.PersistentFlags().StringVar(&k8sSecretsStr, "k8s-secret-injections", "", "optional k8s secret injections (comma-separated) for new environment namespaces (other than image-pull-secret) in SECRET_NAME=VAULT_ID (Vault path using secrets mapping) format. Secret value in Vault must be a JSON-encoded object with two keys: 'data' (map of string to base64-encoded bytes), 'type' (string).")
+	configTestCmd.PersistentFlags().StringVar(&k8sLabelsStr, "k8s-labels", "acyl.dev/managed-by=nitro,istio-injection=enabled", "comma-separated list of key/value pairs in the form <key1>=<value1>,<key2>=<value2>. Note: The combination of labels should be unique in the cluster")
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Printf("error getting working directory: %v", err)
@@ -207,6 +208,9 @@ func checkTestEnvConfig() error {
 	k8scfg := &config.K8sConfig{}
 	if err := k8scfg.ProcessGroupBindings(k8sGroupBindingsStr); err != nil {
 		return errors.Wrap(err, "error in k8s group bindings")
+	}
+	if err := k8scfg.ProcessLabels(k8sLabelsStr); err != nil {
+		return errors.Wrap(err, "error in k8s labels")
 	}
 	k8scfg.SecretInjections = map[string]config.K8sSecret{}
 	if k8sSecretsStr != "" {
@@ -355,7 +359,7 @@ func testConfigSetup() (*nitroenv.Manager, context.Context, *models.RepoRevision
 		ServerConnectRetries:    10,
 		ServerConnectRetryDelay: 2 * time.Second,
 	}
-	ci, err := metahelm.NewChartInstallerWithClientsetFromContext(ib, dl, fs, mc, testEnvCfg.k8sCfg.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, testEnvCfg.k8sCfg.SecretInjections, tcfg, testEnvCfg.kubeCfgPath, testEnvCfg.kubeCtx)
+	ci, err := metahelm.NewChartInstallerWithClientsetFromContext(ib, dl, fs, mc, testEnvCfg.k8sCfg.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, testEnvCfg.k8sCfg.SecretInjections, tcfg, testEnvCfg.kubeCfgPath, testEnvCfg.kubeCtx, testEnvCfg.k8sCfg.Labels)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error getting chart installer")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,7 +93,7 @@ func (kc *K8sConfig) ProcessGroupBindings(gbstr string) error {
 
 // ProcessLabels takes a comma-separated list of labels and popultes the Labels field.
 // We want to ensure that at least one label is provided, otherwise, all resources
-// will be managed by Acyl and could be deleted during cleanup. 
+// will be managed by Acyl and could be deleted during cleanup.
 func (kc *K8sConfig) ProcessLabels(labelsStr string) error {
 	kc.Labels = make(map[string]string)
 	labels := strings.Split(labelsStr, ",")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProcessLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		labelsStr      string
+		expectedErr    bool
+		expectedResult map[string]string
+	}{
+		{
+			name:        "single valid label",
+			labelsStr:   "acyl.dev/managed-by=nitro",
+			expectedErr: false,
+			expectedResult: map[string]string{
+				"acyl.dev/managed-by": "nitro",
+			},
+		},
+		{
+			name:        "multiple valid labels",
+			labelsStr:   "acyl.dev/managed-by=nitro,istio-injection=enabled",
+			expectedErr: false,
+			expectedResult: map[string]string{
+				"acyl.dev/managed-by": "nitro",
+				"istio-injection":     "enabled",
+			},
+		},
+		{
+			name:           "no label",
+			labelsStr:      "",
+			expectedErr:    true,
+			expectedResult: map[string]string{},
+		},
+		{
+			name:           "invalid labels",
+			labelsStr:      "potato,onion",
+			expectedErr:    true,
+			expectedResult: map[string]string{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var k8scfg K8sConfig
+			err := k8scfg.ProcessLabels(tc.labelsStr)
+			receivedErr := err != nil
+			if receivedErr != tc.expectedErr {
+				t.Fatalf("K8sConfig.ProcessLabels received unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(k8scfg.Labels, tc.expectedResult) {
+				t.Fatalf("K8sConfig.ProcessLabels received unexpected results: %v", k8scfg.Labels)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Edit: Updated after initial review
This patch now does the following:

1.  Allows operators to specify labels at the CLI level which will be attached to all kubernetes resources that Nitro creates
2. Now, the cleanup process will basically only delete resources with ALL of the labels specified by the operator. Now that this is configurable, I tried to make it clear that it's important that these values are unique in the cluster so that Acyl doesn't cleanup resources that it didn't actually create.
3. It enables istio injection by default. Given our current istio installation, this doesn't inject sidecars automatically. It's still up to the charts to add annotations to a given pod template spec to enable automatic injection. 

