### PR TITLE
feature: initial support for monorepo

### DIFF
--- a/pkg/api/api_v2.go
+++ b/pkg/api/api_v2.go
@@ -117,7 +117,7 @@ func (api *v2api) register(r *muxtrace.Router) error {
 	if r == nil {
 		return fmt.Errorf("router is nil")
 	}
-	// v2 routes
+	// v2 routesapi
 	r.HandleFunc("/v2/envs/_search", middlewareChain(api.envSearchHandler, authMiddleware.authRequest)).Methods("GET")
 	r.HandleFunc("/v2/envs/{name}", middlewareChain(api.envDetailHandler, authMiddleware.authRequest)).Methods("GET")
 	r.HandleFunc("/v2/eventlog/{id}", middlewareChain(api.eventLogHandler, authMiddleware.authRequest)).Methods("GET")

--- a/pkg/models/nitro.go
+++ b/pkg/models/nitro.go
@@ -94,11 +94,11 @@ func (ram *RepoConfigAppMetadata) SetValueDefaults() {
 // MonorepoAppsMetadata models the app-specific metadata for the primary
 // applications within the monorepo.
 type MonorepoConfigAppMetadata struct {
-	Enabled      bool                    `yaml:"enabled" json:"enabled"`
-	repo         string                  `yaml:"-" json:"repo"`   // set by nitro
-	ref          string                  `yaml:"-" json:"ref"`    // set by nitro
-	branch       string                  `yaml:"-" json:"branch"` // set by nitro
-	Applications []RepoConfigAppMetadata `yaml:"applications" json:"applications"`
+	Enabled      bool                     `yaml:"enabled" json:"enabled"`
+	repo         string                   `yaml:"-" json:"repo"`   // set by nitro
+	ref          string                   `yaml:"-" json:"ref"`    // set by nitro
+	branch       string                   `yaml:"-" json:"branch"` // set by nitro
+	Applications []*RepoConfigAppMetadata `yaml:"applications" json:"applications"`
 }
 
 func (mcam *MonorepoConfigAppMetadata) Branch() string {

--- a/pkg/nitro/meta/charts_fetcher.go
+++ b/pkg/nitro/meta/charts_fetcher.go
@@ -31,7 +31,7 @@ func (mcf MonorepoChartsFetcher) Fetch(
 	fetch func(i int, rc models.RepoConfigDependency) (*ChartLocation, error),
 ) (ChartLocations, error) {
 	// Fetch charts for all applications
-	name := models.GetName(rc.Monorepo.Repo())
+	name := models.GetName(rc.Monorepo.Repo()) // TODO(mk): We should probably include an application name as a requirement in the rpepo config.
 	out := map[string]ChartLocation{}
 	eg, _ := errgroup.WithContext(ctx)
 	chartCount := 0

--- a/pkg/nitro/meta/charts_fetcher.go
+++ b/pkg/nitro/meta/charts_fetcher.go
@@ -1,0 +1,135 @@
+package meta
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dollarshaveclub/acyl/pkg/models"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// QAEnvironmentChartsFetcher is an interface that, given a function for fetching a single chart, can manage fetching charts for an entire QAEnvironment.
+type QAEnvironmentChartsFetcher interface {
+	Fetch(
+		ctx context.Context,
+		rc *models.RepoConfig,
+		basePath string,
+		fetch func(i int, rc models.RepoConfigDependency) (*ChartLocation, error),
+	) (ChartLocations, error)
+}
+
+// MonorepoChartsFetcher manages the fetching of charts from a monorepo.
+type MonorepoChartsFetcher struct{}
+
+func (mcf MonorepoChartsFetcher) Fetch(
+	ctx context.Context,
+	rc *models.RepoConfig,
+	basePath string,
+	fetch func(i int, rc models.RepoConfigDependency) (*ChartLocation, error),
+) (ChartLocations, error) {
+	// Fetch charts for all applications
+	name := models.GetName(rc.Monorepo.Repo())
+	out := map[string]ChartLocation{}
+	eg, _ := errgroup.WithContext(ctx)
+	chartCount := 0
+	for _, app := range rc.Monorepo.Applications {
+		eg.Go(func() error {
+			loc, err := fetch(chartCount, models.RepoConfigDependency{Name: name, AppMetadata: app})
+			if err != nil || loc == nil {
+				return errors.Wrapf(err, "error getting primary application chart: %v, %v", name, app.ChartRepoPath)
+			}
+			return nil
+		})
+		chartCount++
+	}
+
+	// Wait for primary application charts to be fetched
+	if err := eg.Wait(); err != nil {
+		return nil, errors.Wrap(err, "error fetching charts")
+	}
+
+	// Fetch Depedency Charts
+	offsetmap := make(map[int]*models.RepoConfigDependency, rc.Dependencies.Count())
+	couts := make([]ChartLocation, rc.Dependencies.Count())
+	for i, d := range rc.Dependencies.All() {
+		offsetmap[i] = &d
+		eg.Go(func() error {
+			loc, err := fetch(i+chartCount, d)
+			if err != nil || loc == nil {
+				return errors.Wrapf(err, "error getting dependency chart: %v", d.Name)
+			}
+			couts[i] = *loc
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, errors.Wrap(err, "error fetching charts")
+	}
+	for i := 0; i < rc.Dependencies.Count(); i++ {
+		loc := couts[i]
+		d := offsetmap[i]
+		for _, v := range d.ValueOverrides { // Dependency value_overrides override anything in the application metadata
+			vsl := strings.Split(v, "=")
+			if len(vsl) != 2 {
+				return nil, fmt.Errorf("malformed value override: %v", v)
+			}
+			loc.ValueOverrides[vsl[0]] = vsl[1]
+		}
+		out[d.Name] = loc
+	}
+	return out, nil
+}
+
+// SingleAppRepoChartsFetcher manages the fetching of charts from a code repo that only has a single primary application.
+type SingleAppRepoChartsFetcher struct{}
+
+func (scf SingleAppRepoChartsFetcher) Fetch(
+	ctx context.Context,
+	rc *models.RepoConfig,
+	basePath string,
+	fetch func(i int, rc models.RepoConfigDependency) (*ChartLocation, error),
+) (ChartLocations, error) {
+	name := models.GetName(rc.Application.Repo)
+	loc, err := fetch(0, models.RepoConfigDependency{Name: name, AppMetadata: rc.Application})
+	if err != nil || loc == nil {
+		return nil, errors.Wrap(err, "error getting primary repo chart")
+	}
+	out := map[string]ChartLocation{name: *loc}
+	ctx, cf := context.WithTimeout(ctx, 2*time.Minute)
+	defer cf()
+	couts := make([]ChartLocation, rc.Dependencies.Count())
+	offsetmap := make(map[int]*models.RepoConfigDependency, rc.Dependencies.Count())
+	eg, _ := errgroup.WithContext(ctx)
+	for i, d := range rc.Dependencies.All() {
+		d := d
+		i := i
+		offsetmap[i] = &d
+		eg.Go(func() error {
+			loc, err = fetch(i+1, d)
+			if err != nil || loc == nil {
+				return errors.Wrapf(err, "error getting dependency chart: %v", d.Name)
+			}
+			couts[i] = *loc
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, errors.Wrap(err, "error fetching charts")
+	}
+	for i := 0; i < rc.Dependencies.Count(); i++ {
+		loc := couts[i]
+		d := offsetmap[i]
+		for _, v := range d.ValueOverrides { // Dependency value_overrides override anything in the application metadata
+			vsl := strings.Split(v, "=")
+			if len(vsl) != 2 {
+				return nil, fmt.Errorf("malformed value override: %v", v)
+			}
+			loc.ValueOverrides[vsl[0]] = vsl[1]
+		}
+		out[d.Name] = loc
+	}
+	return out, nil
+}

--- a/pkg/nitro/meta/charts_fetcher.go
+++ b/pkg/nitro/meta/charts_fetcher.go
@@ -37,7 +37,7 @@ func (mcf MonorepoChartsFetcher) Fetch(
 	chartCount := 0
 	for _, app := range rc.Monorepo.Applications {
 		eg.Go(func() error {
-			loc, err := fetch(chartCount, models.RepoConfigDependency{Name: name, AppMetadata: app})
+			loc, err := fetch(chartCount, models.RepoConfigDependency{Name: name, AppMetadata: *app})
 			if err != nil || loc == nil {
 				return errors.Wrapf(err, "error getting primary application chart: %v, %v", name, app.ChartRepoPath)
 			}

--- a/pkg/nitro/meta/charts_fetcher_tester.go
+++ b/pkg/nitro/meta/charts_fetcher_tester.go
@@ -1,0 +1,54 @@
+package meta
+
+import (
+	"context"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/dollarshaveclub/acyl/pkg/models"
+)
+
+func fakeFetch(ctx context.Context, rc *models.RepoConfig, basePath string) func(i int, rc models.RepoConfigDependency) (*ChartLocation, error) {
+	return func(i int, d models.RepoConfigDependency) (*ChartLocation, error) {
+		cd := path.Join(basePath, strconv.Itoa(i), d.Name)
+		return &ChartLocation{
+			ChartPath:   cd,
+			VarFilePath: path.Join(cd, "vars.yaml"),
+		}, nil
+	}
+}
+
+// TestFetchChartsMonorepo ensures that the primary applications are included in the ChartLocations result for a Monorepo.
+func TestFetchChartsMonorepo(t *testing.T) {
+	testCases := []struct {
+		rc       *models.RepoConfig
+		basePath string
+		name     string
+	}{{
+		rc: &models.RepoConfig{
+			Monorepo: models.MonorepoConfigAppMetadata{
+				Enabled: true,
+				Applications: []*models.RepoConfigAppMetadata{
+					&models.RepoConfigAppMetadata{
+						DockerfilePath: "app1",
+						Image:          "app1-image",
+					},
+				},
+			},
+		},
+	},
+	}
+	for _, tc := range testCases {
+		fetcher := MonorepoChartsFetcher{}
+		locs, err := fetcher.Fetch(context.Background(), tc.rc, tc.basePath, fakeFetch)
+		if err != nil {
+			t.Fatalf("Received an unexpected error: %v", err)
+		}
+		// TODO(mk): We need to be able to associate the names of the applications with something other than the repo name now!
+	}
+}
+
+func TestFetchChartsStandardRepo(t *testing.T) {
+
+}

--- a/pkg/nitro/meta/testdata/acyl-v2-monorepo.yml
+++ b/pkg/nitro/meta/testdata/acyl-v2-monorepo.yml
@@ -4,7 +4,8 @@ version: 2
 target_branches:
   - master
 
-monrepo:
+monorepo:
+  enabled: true
   applications:
     - chart_path: '.helm/charts/app1'
       chart_vars_path: '.helm/releases/app1/qa.yml'

--- a/pkg/nitro/meta/testdata/acyl-v2-monorepo.yml
+++ b/pkg/nitro/meta/testdata/acyl-v2-monorepo.yml
@@ -1,0 +1,18 @@
+---
+version: 2
+
+target_branches:
+  - master
+
+monrepo:
+  applications:
+    - chart_path: '.helm/charts/app1'
+      chart_vars_path: '.helm/releases/app1/qa.yml'
+      image: quay.io/dollarshaveclub/app1
+      value_overrides:
+        - "foo=bar"
+    - chart_path: '.helm/charts/app2'
+      chart_vars_path: '.helm/releases/app2/qa.yml'
+      image: quay.io/dollarshaveclub/app2
+      value_overrides:
+        - "foo=baz"

--- a/pkg/nitro/metahelm/charts_generator.go
+++ b/pkg/nitro/metahelm/charts_generator.go
@@ -32,7 +32,7 @@ func (mcg MonorepoChartsGenerator) Generate(
 	// Create slice of primary applications in order to maintain DAG.
 	var primaryApps []models.RepoConfigDependency
 	for _, app := range newenv.RC.Monorepo.Applications {
-		rcd := models.RepoConfigDependency{Name: models.GetName(newenv.RC.Monorepo.Repo()), Repo: newenv.RC.Monorepo.Repo(), AppMetadata: app, Requires: []string{}}
+		rcd := models.RepoConfigDependency{Name: models.GetName(newenv.RC.Monorepo.Repo()), Repo: newenv.RC.Monorepo.Repo(), AppMetadata: *app, Requires: []string{}}
 		primaryApps = append(primaryApps, rcd)
 	}
 
@@ -54,8 +54,6 @@ func (mcg MonorepoChartsGenerator) Generate(
 		}
 	}
 	for _, app := range primaryApps {
-		// TODO (mk): Doesn't seem like "i" in the currently supplied genAppChart does anything except provide metadata when logging.
-		// Should we just set as 0 or continue having a unique "i" for each chart.
 		pc, err := genAppChart(0, app)
 		if err != nil {
 			return out, errors.Wrap(err, "error generating primary application chart")

--- a/pkg/nitro/metahelm/charts_generator.go
+++ b/pkg/nitro/metahelm/charts_generator.go
@@ -1,0 +1,108 @@
+package metahelm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dollarshaveclub/acyl/pkg/models"
+	"github.com/dollarshaveclub/metahelm/pkg/metahelm"
+	"github.com/pkg/errors"
+)
+
+// QAEnvironmentChartsGenerator is an interface for generating charts for a QA environment that is ingestible by the packages in github.com/dollarshaveclub/metahelm.
+type QAEnvironmentChartsGenerator interface {
+	Generate(
+		ctx context.Context,
+		ns string, newenv *EnvInfo,
+		cloc ChartLocations,
+		genAppChart func(i int, rcd models.RepoConfigDependency) (_ metahelm.Chart, err error),
+	) (out []metahelm.Chart, err error)
+}
+
+// MonorepoChartsGenerator manages the generation of charts from a monorepo.
+type MonorepoChartsGenerator struct{}
+
+func (mcg MonorepoChartsGenerator) Generate(
+	ctx context.Context,
+	ns string,
+	newenv *EnvInfo,
+	cloc ChartLocations,
+	genAppChart func(i int, rcd models.RepoConfigDependency) (_ metahelm.Chart, err error),
+) (out []metahelm.Chart, err error) {
+	// Create slice of primary applications in order to maintain DAG.
+	var primaryApps []models.RepoConfigDependency
+	for _, app := range newenv.RC.Monorepo.Applications {
+		rcd := models.RepoConfigDependency{Name: models.GetName(newenv.RC.Monorepo.Repo()), Repo: newenv.RC.Monorepo.Repo(), AppMetadata: app, Requires: []string{}}
+		primaryApps = append(primaryApps, rcd)
+	}
+
+	dmap := map[string]struct{}{}
+	reqlist := []string{}
+	for i, d := range newenv.RC.Dependencies.All() {
+		dmap[d.Name] = struct{}{}
+		reqlist = append(reqlist, d.Requires...)
+		dc, err := genAppChart(i+1, d)
+		if err != nil {
+			return out, errors.Wrapf(err, "error generating chart: %v", d.Name)
+		}
+		out = append(out, dc)
+		appendToPrimaryAppsRequires(primaryApps, d.Name)
+	}
+	for _, r := range reqlist { // verify that everything referenced in 'requires' exists
+		if _, ok := dmap[r]; !ok {
+			return out, fmt.Errorf("unknown requires on chart: %v", r)
+		}
+	}
+	for _, app := range primaryApps {
+		// TODO (mk): Doesn't seem like "i" in the currently supplied genAppChart does anything except provide metadata when logging.
+		// Should we just set as 0 or continue having a unique "i" for each chart.
+		pc, err := genAppChart(0, app)
+		if err != nil {
+			return out, errors.Wrap(err, "error generating primary application chart")
+		}
+		out = append(out, pc)
+	}
+	return out, nil
+}
+
+func appendToPrimaryAppsRequires(primaryApps []models.RepoConfigDependency, depName string) {
+	for _, app := range primaryApps {
+		app.Requires = append(app.Requires, depName)
+	}
+}
+
+// SingleAppRepoChartsGenerator manages the fetching of charts from a code repo that only has a single primary application.
+type SingleAppRepoChartsGenerator struct{}
+
+func (scg SingleAppRepoChartsGenerator) Generate(
+	ctx context.Context,
+	ns string,
+	newenv *EnvInfo,
+	cloc ChartLocations,
+	genAppChart func(i int, rcd models.RepoConfigDependency) (_ metahelm.Chart, err error),
+) (out []metahelm.Chart, err error) {
+	prc := models.RepoConfigDependency{Name: models.GetName(newenv.RC.Application.Repo), Repo: newenv.RC.Application.Repo, AppMetadata: newenv.RC.Application, Requires: []string{}}
+	dmap := map[string]struct{}{}
+	reqlist := []string{}
+	for i, d := range newenv.RC.Dependencies.All() {
+		dmap[d.Name] = struct{}{}
+		reqlist = append(reqlist, d.Requires...)
+		dc, err := genAppChart(i+1, d)
+		if err != nil {
+			return out, errors.Wrapf(err, "error generating chart: %v", d.Name)
+		}
+		out = append(out, dc)
+		prc.Requires = append(prc.Requires, d.Name)
+	}
+	for _, r := range reqlist { // verify that everything referenced in 'requires' exists
+		if _, ok := dmap[r]; !ok {
+			return out, fmt.Errorf("unknown requires on chart: %v", r)
+		}
+	}
+	pc, err := genAppChart(0, prc)
+	if err != nil {
+		return out, errors.Wrap(err, "error generating primary application chart")
+	}
+	out = append(out, pc)
+	return out, nil
+}

--- a/pkg/nitro/metahelm/metahelm_test.go
+++ b/pkg/nitro/metahelm/metahelm_test.go
@@ -44,6 +44,10 @@ func chartMap(charts []metahelm.Chart) map[string]metahelm.Chart {
 	return out
 }
 
+func TestMetahelmGenerateChartsMonorepo(t *testing.T) {
+
+}
+
 func TestMetahelmGenerateCharts(t *testing.T) {
 	cases := []struct {
 		name, inputNS, inputEnvName string


### PR DESCRIPTION
This PR adds the ability for Acyl to support monorepos which have multiple primary applications.

In order to support this we have to modify Acyl.yml spec to support a new top-level key, _monorepo_.

This patch also introduces 2 small interfaces
1. QAEnvironmentChartsFetcher
2. QAEnvironmentChartsGenerator

These interfaces allow for multiple implementations for fetching and generating charts in a manner that is ingestible by the packages in github.com/dollarshaveclub/metahelm. 

