### PR TITLE
fix: use background context when seting qa environment status

### DIFF
--- a/pkg/ghclient/github_client.go
+++ b/pkg/ghclient/github_client.go
@@ -137,6 +137,7 @@ func (ghc *GitHubClient) GetTags(ctx context.Context, repo string) ([]BranchInfo
 }
 
 // SetStatus creates or updates a status on repo at commit sha
+// Note that the github client CreateStatus function will bail if the context was canceled. It is often recommended to pass a fresh context to this function.
 func (ghc *GitHubClient) SetStatus(ctx context.Context, repo string, sha string, status *CommitStatus) error {
 	rs := strings.Split(repo, "/")
 	if len(rs) != 2 {

--- a/pkg/nitro/env/env.go
+++ b/pkg/nitro/env/env.go
@@ -187,7 +187,7 @@ func (m *Manager) setGithubCommitStatus(ctx context.Context, rd *models.RepoRevi
 		Description: renderedCSTemplate.Description,
 		TargetURL:   renderedCSTemplate.TargetURL,
 	}
-	err = m.RC.SetStatus(ctx, rd.Repo, rd.SourceSHA, cs)
+	err = m.RC.SetStatus(context.Background(), rd.Repo, rd.SourceSHA, cs)
 	if err != nil {
 		return nil, errors.Wrap(err, "error setting commit status")
 	}

--- a/pkg/nitro/env/env.go
+++ b/pkg/nitro/env/env.go
@@ -324,7 +324,7 @@ func (m *Manager) generateNewEnv(ctx context.Context, rd *models.RepoRevisionDat
 		env = &envs[len(envs)-1]
 		m.log(ctx, "reusing environment db record: %v", env.Name)
 		// update relevant fields
-		if err := m.DL.SetQAEnvironmentStatus(ctx, env.Name, models.Spawned); err != nil {
+		if err := m.DL.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Name, models.Spawned); err != nil {
 			return nil, errors.Wrap(err, "error setting environment status")
 		}
 		m.DL.AddEvent(ctx, env.Name, fmt.Sprintf("reusing environment record for webhook event %v", eventlogger.GetLogger(ctx).ID.String()))
@@ -443,7 +443,7 @@ func (m *Manager) create(ctx context.Context, rd *models.RepoRevisionData) (envn
 	newenv := &newEnv{env: env}
 	defer func() {
 		if err != nil {
-			if err := m.DL.SetQAEnvironmentStatus(ctx, env.Name, models.Failure); err != nil {
+			if err := m.DL.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Name, models.Failure); err != nil {
 				m.log(ctx, "error setting environment status to failed: %v", err)
 			}
 			errmsg := "error creating: " + err.Error()
@@ -537,7 +537,7 @@ func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reaso
 			if len(envs) > 0 {
 				for _, e := range envs {
 					m.log(ctx, "setting %v to status destroyed", e.Name)
-					if err := m.DL.SetQAEnvironmentStatus(ctx, e.Name, models.Destroyed); err != nil {
+					if err := m.DL.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), e.Name, models.Destroyed); err != nil {
 						m.log(ctx, "error setting status to destroyed for environment: %v: %v", e.Name, err)
 					}
 				}
@@ -580,7 +580,7 @@ func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reaso
 		return errors.Wrap(err, "error deleting namespace")
 	}
 	dnend()
-	err = m.DL.SetQAEnvironmentStatus(ctx, env.Name, models.Destroyed)
+	err = m.DL.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Name, models.Destroyed)
 	return errors.Wrap(nitroerrors.SystemError(err), "error setting environment status")
 }
 
@@ -618,7 +618,7 @@ func (m *Manager) update(ctx context.Context, rd *models.RepoRevisionData) (envn
 	ne := &newEnv{env: env}
 	defer func() {
 		if err != nil {
-			if err := m.DL.SetQAEnvironmentStatus(ctx, env.Name, models.Failure); err != nil {
+			if err := m.DL.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Name, models.Failure); err != nil {
 				m.log(ctx, "error setting environment status to failed: %v", err)
 			}
 			m.pushNotification(ctx, ne, notifier.Failure, err.Error())

--- a/pkg/nitro/metahelm/metahelm.go
+++ b/pkg/nitro/metahelm/metahelm.go
@@ -297,7 +297,7 @@ func (ci ChartInstaller) installOrUpgradeIntoExisting(ctx context.Context, env *
 	if ci.kc == nil {
 		return nitroerrors.SystemError(errors.New("k8s client is nil"))
 	}
-	ci.dl.SetQAEnvironmentStatus(ctx, env.Env.Name, models.Updating)
+	ci.dl.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Env.Name, models.Updating)
 	defer func() {
 		if err != nil {
 			if !nitroerrors.IsUserError(err) {
@@ -308,12 +308,12 @@ func (ci ChartInstaller) installOrUpgradeIntoExisting(ctx context.Context, env *
 			if err2 != nil {
 				ci.log(ctx, "error cleaning up namespace: %v", err2)
 			}
-			ci.dl.SetQAEnvironmentStatus(ctx, env.Env.Name, models.Failure)
+			ci.dl.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Env.Name, models.Failure)
 			span.Finish(tracer.WithError(err))
 			return
 		}
 		span.Finish()
-		ci.dl.SetQAEnvironmentStatus(ctx, env.Env.Name, models.Success)
+		ci.dl.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Env.Name, models.Success)
 	}()
 	csl, err := ci.GenerateCharts(ctx, k8senv.Namespace, env, cl)
 	if err != nil {
@@ -359,9 +359,9 @@ func (ci ChartInstaller) BuildAndInstallCharts(ctx context.Context, newenv *EnvI
 			if err2 != nil {
 				ci.log(ctx, "error cleaning up namespace: %v", err2)
 			}
-			ci.dl.SetQAEnvironmentStatus(ctx, newenv.Env.Name, models.Failure)
+			ci.dl.SetQAEnvironmentStatus(context.Background(), newenv.Env.Name, models.Failure)
 		} else {
-			ci.dl.SetQAEnvironmentStatus(ctx, newenv.Env.Name, models.Success)
+			ci.dl.SetQAEnvironmentStatus(context.Background(), newenv.Env.Name, models.Success)
 		}
 	}()
 	if err := ci.writeK8sEnvironment(ctx, newenv, ns); err != nil {

--- a/pkg/persistence/pg.go
+++ b/pkg/persistence/pg.go
@@ -279,7 +279,8 @@ func (p *PGLayer) GetQAEnvironmentsByUser(ctx context.Context, user string) ([]Q
 	return p.collectRows(p.db.QueryContext(ctx, `SELECT `+models.QAEnvironment{}.Columns()+` from qa_environments WHERE username = $1;`, user))
 }
 
-// SetQAEnvironmentStatus sets a specific QAEnvironment's status
+// SetQAEnvironmentStatus sets a specific QAEnvironment's status.
+// Note that this will bail if the context was canceled. It is often recommended to pass a fresh context to this function.
 func (p *PGLayer) SetQAEnvironmentStatus(ctx context.Context, name string, status EnvironmentStatus) error {
 	if isCancelled(ctx.Done()) {
 		return errors.Wrap(ctx.Err(), "error setting qa environment status")

--- a/pkg/spawner/spawner.go
+++ b/pkg/spawner/spawner.go
@@ -814,7 +814,7 @@ func (qs *QASpawner) updateQAMetadata(ctx context.Context, name string, status E
 	if err != nil {
 		return nil, fmt.Errorf("error setting created: %v: %v", name, err)
 	}
-	err = qs.dl.SetQAEnvironmentStatus(ctx, name, status)
+	err = qs.dl.SetQAEnvironmentStatus(context.Background(), name, status)
 	if err != nil {
 		return nil, fmt.Errorf("error setting status: %v: %v", name, err)
 	}
@@ -986,7 +986,7 @@ func (qs *QASpawner) create(ctx context.Context, rd RepoRevisionData, updating b
 				qs.logger.Printf("error setting Github failure status: %v", err2)
 			}
 			if name != "" && !qs.isDestroyed(ctx, name) {
-				err2 = qs.dl.SetQAEnvironmentStatus(ctx, name, Failure)
+				err2 = qs.dl.SetQAEnvironmentStatus(context.Background(), name, Failure)
 				if err2 != nil {
 					qs.logger.Printf("error setting environment to failed: %v", err2)
 				}
@@ -1068,7 +1068,7 @@ func (qs *QASpawner) destroyQA(ctx context.Context, qae *QAEnvironment) error {
 		qs.logger.Printf("error terminating Amino environment: %v", err)
 	}
 
-	return qs.dl.SetQAEnvironmentStatus(ctx, qae.Name, Destroyed)
+	return qs.dl.SetQAEnvironmentStatus(context.Background(), qae.Name, Destroyed)
 }
 
 func (qs *QASpawner) destroy(ctx context.Context, rd RepoRevisionData, reason QADestroyReason, notify bool) (result []string, resultError error) {
@@ -1127,7 +1127,7 @@ func (qs *QASpawner) DestroyExplicitly(ctx context.Context, qa *QAEnvironment, r
 }
 
 func (qs *QASpawner) finalize(ctx context.Context, name string, state EnvironmentStatus, status string, desc string, failureMessage string) error {
-	err := qs.dl.SetQAEnvironmentStatus(ctx, name, state)
+	err := qs.dl.SetQAEnvironmentStatus(context.Background(), name, state)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes: https://github.com/dollarshaveclub/acyl/issues/39


When operations get canceled, we still want to be able to update the status of the qa environment through the data layer. So we should be passing the background context so that it can still update the status through the datalayer in these situations. 