### PR TITLE
nitro: more robust environment deletion

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2275,6 +2275,7 @@
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",

--- a/pkg/nitro/env/env.go
+++ b/pkg/nitro/env/env.go
@@ -582,7 +582,7 @@ func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reaso
 		m.log(ctx, "beginning k8s delete for env: %v", k8senv.EnvName)
 
 		dnend := m.MC.Timing(mpfx+"delete_namespace_duration", "triggering_repo:"+rd.Repo)
-		
+
 		// delete helm releases from DB only
 		if _, err := m.DL.DeleteHelmReleasesForEnv(ctx2, k8senv.EnvName); err != nil {
 			m.log(ctx, "error deleting helm releases from DB: %v", err)


### PR DESCRIPTION
This Patch ignores a namespace not found error when attempting to delete a namespace. Since there is nothing to delete, we do not need to return an error in this case. 