### PR TITLE
Non-blocking namespace deletion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.11-alpine
+FROM golang:1.13-alpine
 
 COPY . /go/src/github.com/dollarshaveclub/acyl
 RUN cd /go/src/github.com/dollarshaveclub/acyl && \
 CGO_ENABLED=0 go install github.com/dollarshaveclub/acyl
 
-FROM alpine:3.9
+FROM alpine:3.10
 
 RUN mkdir -p /go/bin/ /opt/integration /opt/html /opt/migrations && \
-apk --no-cache add ca-certificates
+apk --no-cache add ca-certificates && apk --no-cache upgrade
 COPY --from=0 /go/bin/acyl /go/bin/acyl
 COPY --from=0 /go/src/github.com/dollarshaveclub/acyl/testdata/integration/* /opt/integration/
 COPY --from=0 /go/src/github.com/dollarshaveclub/acyl/data/words.json.gz /opt/

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -355,7 +355,7 @@ func testConfigSetup() (*nitroenv.Manager, context.Context, *models.RepoRevision
 		ServerConnectRetries:    10,
 		ServerConnectRetryDelay: 2 * time.Second,
 	}
-	ci, err := metahelm.NewChartInstallerWithClientsetFromContext(ib, dl, fs, mc, testEnvCfg.k8sCfg.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, testEnvCfg.k8sCfg.SecretInjections, tcfg, testEnvCfg.kubeCfgPath, testEnvCfg.kubeCtx)
+	ci, err := metahelm.NewChartInstallerWithClientsetFromContext(ib, dl, fs, mc, testEnvCfg.k8sCfg.GroupBindings, testEnvCfg.k8sCfg.PrivilegedRepoWhitelist, testEnvCfg.k8sCfg.SecretInjections, tcfg, testEnvCfg.kubeCfgPath, testEnvCfg.kubeCtx)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error getting chart installer")
 	}

--- a/pkg/nitro/env/env_test.go
+++ b/pkg/nitro/env/env_test.go
@@ -799,6 +799,7 @@ func TestDelete(t *testing.T) {
 				CI: ci,
 			}
 			err := m.Delete(context.Background(), &c.inputRDD, models.DestroyApiRequest)
+			time.Sleep(10*time.Millisecond) // give time for async delete to complete
 			c.verifyFunc(err, t)
 		})
 	}

--- a/pkg/nitro/metahelm/fake.go
+++ b/pkg/nitro/metahelm/fake.go
@@ -98,5 +98,8 @@ func (fi FakeInstaller) DeleteReleases(ctx context.Context, k8senv *models.Kuber
 	return nil
 }
 func (fi FakeInstaller) DeleteNamespace(ctx context.Context, k8senv *models.KubernetesEnvironment) error {
+	if fi.DL != nil {
+		return fi.DL.DeleteK8sEnv(ctx, k8senv.EnvName)
+	}
 	return nil
 }


### PR DESCRIPTION
- During environment destroys, do not attempt to delete Helm releases anymore, only delete the namespace (DB is cleaned up, however).
- Do k8s namespace deletion asynchronously with retries and an independent context timeout.
- Fix a bug with `acyl config test create` where the CLI privileged repo whitelist was not being propagated.
- Update Dockerfile to go 1.13

Fixes #43 