### PR TITLE
Timeout Notification

### DIFF
--- a/.helm/charts/acyl/templates/deployment.yaml
+++ b/.helm/charts/acyl/templates/deployment.yaml
@@ -95,6 +95,10 @@ spec:
           - "{{ .Values.app.failure_reports.s3.keyprefix }}"
           - "--k8s-group-bindings"
           - "{{ .Values.app.k8s_group_bindings }}"
+          {{ if .Values.app.operation_timeout_override }}
+          - "--operation-timeout-override"
+          - "{{ .Values.app.operation_timeout_override }}"
+          {{ end }}
     {{ end }}
         ports:
         - containerPort: {{ .Values.service.internalPort }}

--- a/.helm/charts/acyl/values.yaml
+++ b/.helm/charts/acyl/values.yaml
@@ -34,6 +34,7 @@ app:
   k8s_group_bindings: ""
   k8s_secret_injections: "image-pull-secret=k8s/image_pull_secret"
   k8s_client_disable_http2: true # work around bug in using HTTP2 for k8s client calls
+  operation_timeout_override: ''
   failure_reports:
     s3:
       region: ''

--- a/acyl.yml
+++ b/acyl.yml
@@ -15,9 +15,14 @@ application:
   #   - "app.secrets_mapping=ACYL_{{ .ID }}"
   #   - "app.secrets_from_env=true"
   #   - "app.k8s_secret_injections="
+  #   - "ingress.traefik.enabled=false"
+  #   - "app.furan_addr=furan:4001"
 
 dependencies:
   direct:
+    - repo: dollarshaveclub/furan
+      name: furan
+      default_branch: local-dqa-fixes
     - chart_repo_path: 'kubernetes/charts@8bd8912453404fc1bc45cc91de70c54bafb8a7ec:stable/postgresql'
       chart_vars_repo_path: 'kubernetes/charts@8bd8912453404fc1bc45cc91de70c54bafb8a7ec:stable/postgresql/values.yaml'
       value_overrides:

--- a/acyl.yml
+++ b/acyl.yml
@@ -17,7 +17,7 @@ application:
   #   - "app.k8s_secret_injections="
   #   - "ingress.traefik.enabled=false"
   #   - "app.furan_addr=furan:4001"
-  #   - "app.operation_timeout_override=1m"
+  #   - "app.operation_timeout_override=10m"
 
 dependencies:
   direct:

--- a/acyl.yml
+++ b/acyl.yml
@@ -17,6 +17,7 @@ application:
   #   - "app.k8s_secret_injections="
   #   - "ingress.traefik.enabled=false"
   #   - "app.furan_addr=furan:4001"
+  #   - "app.operation_timeout_override=1m"
 
 dependencies:
   direct:

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -113,6 +113,7 @@ func init() {
 	serverCmd.PersistentFlags().StringVar(&dogstatsdTags, "dogstatsd-tags", "", "Comma-separated list of tags to add to dogstatsd metrics (TAG:VALUE)")
 	serverCmd.PersistentFlags().StringVar(&datadogTracingAgentAddr, "datadog-tracing-agent-addr", "127.0.0.1:8126", "Address of datadog tracing agent")
 	serverCmd.PersistentFlags().StringVar(&datadogServiceName, "datadog-service-name", "acyl", "Default service name to be used for Datadog APM")
+	serverCmd.PersistentFlags().DurationVar(&serverConfig.OperationTimeoutOverride, "operation-timeout-override", 0, "Override for operation timeout (ex: 10m)")
 	RootCmd.AddCommand(serverCmd)
 }
 
@@ -265,6 +266,7 @@ func server(cmd *cobra.Command, args []string) {
 			S3Config:             s3config,
 			GlobalLimit:          serverConfig.GlobalEnvironmentLimit,
 		}
+		nitromgr.OperationTimeout = serverConfig.OperationTimeoutOverride // Zero means use default defined in pkg/nitro/env
 		loadFailureTemplate(nitromgr)
 		envspawner = &nitroenv.CombinedSpawner{
 			DL:      dl,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dollarshaveclub/pvc"
 	"github.com/pkg/errors"
@@ -27,6 +28,7 @@ type ServerConfig struct {
 	DebugEndpointsIPWhitelists []string
 	NitroFeatureFlag           bool
 	NotificationsDefaultsJSON  string
+	OperationTimeoutOverride   time.Duration
 }
 
 type PGConfig struct {

--- a/pkg/nitro/env/env.go
+++ b/pkg/nitro/env/env.go
@@ -572,9 +572,6 @@ func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reaso
 		// processEnvConfig() always returns a valid newenv
 		m.log(ctx, "error processing environment config: %v", err)
 	}
-	ctx, cf := context.WithCancel(ctx)
-	defer cf()
-	go m.enforceTimeout(ctx, cf, ne)
 	defer func() {
 		if err != nil {
 			m.pushNotification(ctx, ne, notifier.Failure, "error destroying: "+err.Error())
@@ -620,6 +617,7 @@ func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reaso
 		dnend()
 		m.log(ctx, "completed k8s delete for env: %v", k8senv.EnvName)
 	}()
+	// use independent context for setting the status
 	err = m.DL.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Name, models.Destroyed)
 	return errors.Wrap(nitroerrors.SystemError(err), "error setting environment status")
 }

--- a/pkg/nitro/env/env.go
+++ b/pkg/nitro/env/env.go
@@ -438,6 +438,7 @@ func (m *Manager) enforceTimeout(ctx context.Context, cf context.CancelFunc, new
 	select {
 	case <-time.After(to):
 		m.pushNotification(ctx, newenv, notifier.Failure, fmt.Sprintf("timeout reached (%v), aborting", to))
+		m.log(ctx, "timed out (%v), cancelling context and aborting", to)
 		cf()
 	case <-ctx.Done():
 	}

--- a/pkg/persistence/helm.go
+++ b/pkg/persistence/helm.go
@@ -13,7 +13,7 @@ import (
 var _ HelmDataLayer = &PGLayer{}
 
 func (pg *PGLayer) GetHelmReleasesForEnv(ctx context.Context, name string) ([]models.HelmRelease, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting helm releases for env")
 	}
 	q := `SELECT ` + models.HelmRelease{}.Columns() + ` FROM helm_releases WHERE env_name = $1;`
@@ -21,7 +21,7 @@ func (pg *PGLayer) GetHelmReleasesForEnv(ctx context.Context, name string) ([]mo
 }
 
 func (pg *PGLayer) UpdateHelmReleaseRevision(ctx context.Context, envname, release, revision string) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error updating helm relese revision")
 	}
 	q := `UPDATE helm_releases SET revision_sha = $1 WHERE env_name = $2 AND release = $3;`
@@ -30,7 +30,7 @@ func (pg *PGLayer) UpdateHelmReleaseRevision(ctx context.Context, envname, relea
 }
 
 func (pg *PGLayer) CreateHelmReleasesForEnv(ctx context.Context, releases []models.HelmRelease) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error creating helm releases for env")
 	}
 	tx, err := pg.db.Begin()
@@ -57,7 +57,7 @@ func (pg *PGLayer) CreateHelmReleasesForEnv(ctx context.Context, releases []mode
 }
 
 func (pg *PGLayer) DeleteHelmReleasesForEnv(ctx context.Context, name string) (uint, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return 0, errors.Wrap(ctx.Err(), "error deleting helm releases for env")
 	}
 	q := `DELETE FROM helm_releases WHERE env_name = $1;`

--- a/pkg/persistence/k8s_envs.go
+++ b/pkg/persistence/k8s_envs.go
@@ -13,7 +13,7 @@ var _ K8sEnvDataLayer = &PGLayer{}
 // GetK8sEnv gets a k8s environment by environment name
 func (pg *PGLayer) GetK8sEnv(ctx context.Context, name string) (*models.KubernetesEnvironment, error) {
 	out := &models.KubernetesEnvironment{}
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting k8s env")
 	}
 	q := `SELECT ` + models.KubernetesEnvironment{}.Columns() + ` FROM kubernetes_environments WHERE env_name = $1;`
@@ -28,7 +28,7 @@ func (pg *PGLayer) GetK8sEnv(ctx context.Context, name string) (*models.Kubernet
 
 // GetK8sEnvsByNamespace returns any KubernetesEnvironments associated with a specific namespace name
 func (pg *PGLayer) GetK8sEnvsByNamespace(ctx context.Context, ns string) ([]models.KubernetesEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting k8s env by namespace")
 	}
 	q := `SELECT ` + models.KubernetesEnvironment{}.Columns() + ` FROM kubernetes_environments WHERE namespace = $1;`
@@ -37,7 +37,7 @@ func (pg *PGLayer) GetK8sEnvsByNamespace(ctx context.Context, ns string) ([]mode
 
 // CreateK8sEnv inserts a new k8s environment into the DB
 func (pg *PGLayer) CreateK8sEnv(ctx context.Context, env *models.KubernetesEnvironment) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error creating k8s env")
 	}
 	q := `INSERT INTO kubernetes_environments (` + env.InsertColumns() + `) VALUES (` + env.InsertParams() + `);`
@@ -47,7 +47,7 @@ func (pg *PGLayer) CreateK8sEnv(ctx context.Context, env *models.KubernetesEnvir
 
 // DeleteK8sEnv deletes a k8s environment from the DB
 func (pg *PGLayer) DeleteK8sEnv(ctx context.Context, name string) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error deleting k8s env")
 	}
 	q := `DELETE FROM kubernetes_environments WHERE env_name = $1;`
@@ -57,7 +57,7 @@ func (pg *PGLayer) DeleteK8sEnv(ctx context.Context, name string) error {
 
 // UpdateK8sEnvTillerAddr updates an existing k8s environment with the provided tiller address
 func (pg *PGLayer) UpdateK8sEnvTillerAddr(ctx context.Context, envname, taddr string) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error update k8s env tiller address")
 	}
 	q := `UPDATE kubernetes_environments SET tiller_addr = $1 WHERE env_name = $2;`

--- a/pkg/persistence/pg.go
+++ b/pkg/persistence/pg.go
@@ -23,9 +23,9 @@ import (
 
 var _ DataLayer = &PGLayer{}
 
-func isCancelled(done <-chan struct{}) bool {
+func isCancelled(ctx context.Context) bool {
 	select {
-	case <-done:
+	case <-ctx.Done():
 		return true
 	default:
 		return false
@@ -74,7 +74,7 @@ func (p *PGLayer) DB() *sqlx.DB {
 
 // CreateQAEnvironment persists a new QA record.
 func (p *PGLayer) CreateQAEnvironment(ctx context.Context, qae *QAEnvironment) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error creating qa environment")
 	}
 	if qae.Name == "" {
@@ -103,7 +103,7 @@ func (p *PGLayer) CreateQAEnvironment(ctx context.Context, qae *QAEnvironment) e
 
 // GetQAEnvironment finds a QAEnvironment by the name field.
 func (p *PGLayer) GetQAEnvironment(ctx context.Context, name string) (*QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting qa environment")
 	}
 	var qae QAEnvironment
@@ -159,7 +159,7 @@ func (p *PGLayer) collectRows(rows *sql.Rows, err error) ([]QAEnvironment, error
 
 // GetQAEnvironments returns all QA records
 func (p *PGLayer) GetQAEnvironments(ctx context.Context) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting qa environments")
 	}
 	return p.collectRows(p.db.QueryContext(ctx, `SELECT `+models.QAEnvironment{}.Columns()+` FROM qa_environments;`))
@@ -168,7 +168,7 @@ func (p *PGLayer) GetQAEnvironments(ctx context.Context) ([]QAEnvironment, error
 // DeleteQAEnvironment deletes a QA environment record. The environment must have status Destroyed.
 // Callers must ensure that the underlying k8s environment has been deleted prior to calling this, otherwise potentially orphan k8s resources will be left running.
 func (p *PGLayer) DeleteQAEnvironment(ctx context.Context, name string) (err error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error deleting qa environment")
 	}
 	txn, err := p.db.Begin()
@@ -210,7 +210,7 @@ func (p *PGLayer) DeleteQAEnvironment(ctx context.Context, name string) (err err
 
 // GetQAEnvironmentsByStatus gets all environmens matching status. TODO(geoffrey): Revisit raw_status with @benjamen
 func (p *PGLayer) GetQAEnvironmentsByStatus(ctx context.Context, status string) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting qa environments by status")
 	}
 	s, err := models.EnvironmentStatusFromString(status)
@@ -222,7 +222,7 @@ func (p *PGLayer) GetQAEnvironmentsByStatus(ctx context.Context, status string) 
 
 // GetRunningQAEnvironments returns all environments with status "success", "updating" or "spawned", in ascending order of creation time.
 func (p *PGLayer) GetRunningQAEnvironments(ctx context.Context) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting running qa environments")
 	}
 	return p.collectRows(p.db.QueryContext(ctx, `SELECT `+models.QAEnvironment{}.Columns()+` from qa_environments WHERE status = $1 OR status = $2 OR status = $3 ORDER BY created ASC;`, models.Spawned, models.Success, models.Updating))
@@ -230,7 +230,7 @@ func (p *PGLayer) GetRunningQAEnvironments(ctx context.Context) ([]QAEnvironment
 
 // GetQAEnvironmentsByRepoAndPR teturns all environments which have matching repo AND pull request.
 func (p *PGLayer) GetQAEnvironmentsByRepoAndPR(ctx context.Context, repo string, pr uint) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting qa environments by repo and pr")
 	}
 	return p.collectRows(p.db.QueryContext(ctx, `SELECT `+models.QAEnvironment{}.Columns()+` from qa_environments WHERE repo = $1 AND pull_request = $2;`, repo, pr))
@@ -238,7 +238,7 @@ func (p *PGLayer) GetQAEnvironmentsByRepoAndPR(ctx context.Context, repo string,
 
 // GetQAEnvironmentsByRepo returns all environments which have matching repo.
 func (p *PGLayer) GetQAEnvironmentsByRepo(ctx context.Context, repo string) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting environments by repo")
 	}
 	return p.collectRows(p.db.QueryContext(ctx, `SELECT `+models.QAEnvironment{}.Columns()+` from qa_environments WHERE repo = $1;`, repo))
@@ -246,7 +246,7 @@ func (p *PGLayer) GetQAEnvironmentsByRepo(ctx context.Context, repo string) ([]Q
 
 // GetQAEnvironmentBySourceSHA returns an environment with a matching sourceSHA.
 func (p *PGLayer) GetQAEnvironmentBySourceSHA(ctx context.Context, sourceSHA string) (*QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting environment by source sha")
 	}
 	var qae QAEnvironment
@@ -265,7 +265,7 @@ func (p *PGLayer) GetQAEnvironmentBySourceSHA(ctx context.Context, sourceSHA str
 
 // GetQAEnvironmentsBySourceBranch returns all environments which have matching sourceBranch.
 func (p *PGLayer) GetQAEnvironmentsBySourceBranch(ctx context.Context, sourceBranch string) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting qa environments by source branch")
 	}
 	return p.collectRows(p.db.QueryContext(ctx, `SELECT `+models.QAEnvironment{}.Columns()+` from qa_environments WHERE source_branch = $1;`, sourceBranch))
@@ -273,7 +273,7 @@ func (p *PGLayer) GetQAEnvironmentsBySourceBranch(ctx context.Context, sourceBra
 
 // GetQAEnvironmentsByUser retrieve all QAEnvironment by user (User is username in the DB see models/models.go).
 func (p *PGLayer) GetQAEnvironmentsByUser(ctx context.Context, user string) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting qa environments by user")
 	}
 	return p.collectRows(p.db.QueryContext(ctx, `SELECT `+models.QAEnvironment{}.Columns()+` from qa_environments WHERE username = $1;`, user))
@@ -282,7 +282,7 @@ func (p *PGLayer) GetQAEnvironmentsByUser(ctx context.Context, user string) ([]Q
 // SetQAEnvironmentStatus sets a specific QAEnvironment's status.
 // Note that this will bail if the context was canceled. It is often recommended to pass a fresh context to this function.
 func (p *PGLayer) SetQAEnvironmentStatus(ctx context.Context, name string, status EnvironmentStatus) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error setting qa environment status")
 	}
 	_, err := p.db.ExecContext(ctx, `UPDATE qa_environments SET status = $1 WHERE name = $2;`, status, name)
@@ -309,7 +309,7 @@ func (p *PGLayer) SetQAEnvironmentRepoData(ctx context.Context, name string, rep
 		repo.BaseBranch == "" {
 		return fmt.Errorf("all fields of RepoRevisionData must be supplied")
 	}
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error setting qa environment repo data")
 	}
 	_, err := p.db.ExecContext(ctx, `UPDATE qa_environments SET repo = $1, source_sha = $2, pull_request = $3, base_sha = $4, source_branch = $5, base_branch = $6, username = $7 WHERE name = $8;`, repo.Repo, repo.SourceSHA, repo.PullRequest, repo.BaseSHA, repo.SourceBranch, repo.BaseBranch, repo.User, name)
@@ -318,7 +318,7 @@ func (p *PGLayer) SetQAEnvironmentRepoData(ctx context.Context, name string, rep
 
 // SetQAEnvironmentRefMap sets a specific QAEnvironment's RefMap.
 func (p *PGLayer) SetQAEnvironmentRefMap(ctx context.Context, name string, refMap RefMap) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error setting qa environment ref map")
 	}
 	qae := models.QAEnvironment{RefMap: refMap}
@@ -328,7 +328,7 @@ func (p *PGLayer) SetQAEnvironmentRefMap(ctx context.Context, name string, refMa
 
 // SetQAEnvironmentCommitSHAMap sets a specific QAEnvironment's commitSHAMap.
 func (p *PGLayer) SetQAEnvironmentCommitSHAMap(ctx context.Context, name string, commitSHAMap RefMap) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error setting qa environment commit sha map")
 	}
 	qae := models.QAEnvironment{CommitSHAMap: commitSHAMap}
@@ -338,7 +338,7 @@ func (p *PGLayer) SetQAEnvironmentCommitSHAMap(ctx context.Context, name string,
 
 // SetQAEnvironmentCreated sets a specific QAEnvironment's created time.
 func (p *PGLayer) SetQAEnvironmentCreated(ctx context.Context, name string, created time.Time) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error setting qa environment creation time")
 	}
 	created = created.Truncate(1 * time.Microsecond)
@@ -349,7 +349,7 @@ func (p *PGLayer) SetQAEnvironmentCreated(ctx context.Context, name string, crea
 // GetExtantQAEnvironments finds any environments for the given repo/PR combination that
 // are not status Destroyed
 func (p *PGLayer) GetExtantQAEnvironments(ctx context.Context, repo string, pr uint) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting extant qa environments")
 	}
 	return p.collectRows(p.db.QueryContext(ctx, `SELECT `+models.QAEnvironment{}.Columns()+` FROM qa_environments WHERE repo = $1 AND pull_request = $2 AND status != $3 AND status != $4;`, repo, pr, models.Destroyed, models.Failure))
@@ -357,7 +357,7 @@ func (p *PGLayer) GetExtantQAEnvironments(ctx context.Context, repo string, pr u
 
 // SetAminoEnvironmentID sets the Amino environment ID for an environment.
 func (p *PGLayer) SetAminoEnvironmentID(ctx context.Context, name string, did int) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error setting amino environment id")
 	}
 	_, err := p.db.ExecContext(ctx, `UPDATE qa_environments SET amino_environment_id = $1 WHERE name = $2;`, did, name)
@@ -367,7 +367,7 @@ func (p *PGLayer) SetAminoEnvironmentID(ctx context.Context, name string, did in
 // SetAminoServiceToPort sets the Amino service port metadata for an
 // environment.
 func (p *PGLayer) SetAminoServiceToPort(ctx context.Context, name string, serviceToPort map[string]int64) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error setting amino service to port")
 	}
 	qae := models.QAEnvironment{AminoServiceToPort: serviceToPort}
@@ -378,7 +378,7 @@ func (p *PGLayer) SetAminoServiceToPort(ctx context.Context, name string, servic
 // SetAminoKubernetesNamespace sets the Kubernetes namespace for an
 // environment.
 func (p *PGLayer) SetAminoKubernetesNamespace(ctx context.Context, name string, namespace string) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error setting amino k8s namespace")
 	}
 	_, err := p.db.ExecContext(ctx, `UPDATE qa_environments SET amino_kubernetes_namespace = $1 WHERE name = $2;`, namespace, name)
@@ -387,7 +387,7 @@ func (p *PGLayer) SetAminoKubernetesNamespace(ctx context.Context, name string, 
 
 // AddEvent adds an event a particular QAEnvironment.
 func (p *PGLayer) AddEvent(ctx context.Context, name string, msg string) error {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error adding event")
 	}
 	event := QAEnvironmentEvent{
@@ -405,7 +405,7 @@ func (p *PGLayer) AddEvent(ctx context.Context, name string, msg string) error {
 // Search finds environments that satsify the parameters given.
 // Multiple parameters are combined with implicit AND.
 func (p *PGLayer) Search(ctx context.Context, opts models.EnvSearchParameters) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error searching for environments")
 	}
 	if opts.Pr != 0 && opts.Repo == "" {
@@ -459,7 +459,7 @@ func (p *PGLayer) Search(ctx context.Context, opts models.EnvSearchParameters) (
 // Recency is defined by created/updated timestamps.
 // The returned slice is in descending order of recency.
 func (p *PGLayer) GetMostRecent(ctx context.Context, n uint) ([]QAEnvironment, error) {
-	if isCancelled(ctx.Done()) {
+	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting most recent")
 	}
 	q := `SELECT ` + models.QAEnvironment{}.Columns() + fmt.Sprintf(` from qa_environments WHERE created >= (current_timestamp - interval '%v days');`, n)


### PR DESCRIPTION
Refactor operation timeouts to enable Acyl to send timeout notifications. Fixes #58.

- Enforce timeouts in `pkg/nitro/env` instead of simply letting the context cancel, so we can reliably send timeout notifications (previously they either were never sent, or with a cryptic "context cancelled" error message).
- (Delete operations are fully async so there is no meaningful timeout possible.)
- Increase the global operation timeout in the API layer as a safeguard against goroutines that hang forever.
- Add tests for timeouts and add some functionality to the datalayer fake.