### PR TITLE
Fix logic ignoring create_cluster_role_binding flag

### DIFF
--- a/.helm/charts/acyl/templates/cluster-role-binding.yaml
+++ b/.helm/charts/acyl/templates/cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-{{ if (not .Values.is_dqa) and .Values.create_cluster_role_binding }}
+{{ if and (not .Values.is_dqa) (.Values.create_cluster_role_binding) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Found that the existing logic wasn't working, possibly due in part to the newer version of helm, also failing though on jenkins. This fixes the issue.