### PR TITLE
DO NOT MERGE vault agent injector helm chart update POC

### DIFF
--- a/.helm/charts/acyl/templates/_helpers.tpl
+++ b/.helm/charts/acyl/templates/_helpers.tpl
@@ -13,3 +13,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "fullname" -}}
 {{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create .Data.value template for Vault Agent Injector
+Note the newline \n and spaces to maintain indentation
+*/}}
+{{- define "vault-agent-default-dsc-secrets-v1-template" -}}
+{{- $secrets_prefix := .Values.vault.secrets_prefix -}}
+{{- range .Values.vault.secrets }}
+
+vault.hashicorp.com/agent-inject-secret-{{ .name }}: {{- printf "\"%v%v\"\n" $secrets_prefix .path -}}
+vault.hashicorp.com/agent-inject-template-{{- printf "%v: |" .name  -}}
+{{- printf "\n  {{- with secret \"%v%v\" -}}\n" $secrets_prefix .path  -}}
+{{- printf "  {{ .Data.value }}\n" -}}  
+{{- println "  {{- end }}" -}}
+{{- end -}}
+{{- end -}}

--- a/.helm/charts/acyl/templates/deployment.yaml
+++ b/.helm/charts/acyl/templates/deployment.yaml
@@ -19,6 +19,15 @@ spec:
       labels:
         app: {{ template "fullname" . }}
         appsel: acyl
+      annotations:
+{{- if eq .Values.vault.agent_injector.enabled true }}
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/agent-init-first: "{{ .Values.vault.agent_injector.init_first }}"
+        vault.hashicorp.com/log-level: "{{ .Values.vault.agent_injector.log_level }}"
+        vault.hashicorp.com/auth-path: "auth/{{ .Values.vault.auth_path }}"
+        vault.hashicorp.com/role: "{{ .Values.vault.role }}"
+{{ include "vault-agent-default-dsc-secrets-v1-template" . | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceaccount }}
       terminationGracePeriodSeconds: 1830 # 30min + 30s

--- a/.helm/charts/acyl/values.yaml
+++ b/.helm/charts/acyl/values.yaml
@@ -60,6 +60,49 @@ vault:
   use_k8s_auth: true
   role: acyl
   auth_path: "kubernetes"
+  agent_injector:
+    enabled: true
+    init_first: false
+    log_level: info
+  secrets_prefix: "secret/services/acyl/qa/"
+  secrets:
+  - name: awsAccessKeyIDid
+    path: aws/access_key_id
+  - name: awsSecretAccessKeyid
+    path: aws/secret_access_key
+  - name: githubHookSecretid         
+    path: github/hook_secret
+  - name: githubTokenid
+    path: github/token
+  - name: githubAppID                
+    path: github/app/id
+  - name: githubAppPK                
+    path: github/app/private_key
+  - name: githubAppHookSecret        
+    path: github/app/hook_secret
+  - name: githubOAuthInstID          
+    path: github/app/oauth/installation_id
+  - name: githubOAuthClientID        
+    path: github/app/oauth/client/id
+  - name: githubOAuthClientSecret    
+    path: github/app/oauth/client/secret
+  - name: githubOAuthCookieEncKey    
+    path: github/app/oauth/cookie/encryption_key
+  - name: githubOAuthCookieAuthKey   
+    path: github/app/oauth/cookie/authentication_key
+  - name: githubOAuthUserTokenEncKey 
+    path: github/app/oauth/user_token/encryption_key
+  - name: apiKeysid                  
+    path: api_keys
+  - name: slackTokenid               
+    path: slack/token
+  - name: tlsCertid                  
+    path: tls/cert
+  - name: tlsKeyid                   
+    path: tls/key
+  - name: dbURIid                    
+    path: db/uri
+
 cronautoscaling:
   enabled: false
   jobs: []
@@ -87,3 +130,4 @@ resources:
   requests:
     cpu: 1
     memory: 256Mi
+


### PR DESCRIPTION
This is a POC PR of Helm Chart updates so ACYL could use a Vault Agent Injector in the K8S cluster it runs in.

The .helm/charts/template/_helper.tpl and values.yaml file varies from the vault-injector-example to account for backwards compatibility with an existing `vault:` section in the yaml.

