### PR TITLE
locker: print notification payload for debugging

### DIFF
--- a/pkg/locker/locker.go
+++ b/pkg/locker/locker.go
@@ -184,6 +184,7 @@ func (p *PreemptiveLocker) Lock(ctx context.Context) (ch <-chan NotificationPayl
 
 	p.key = key
 	span.SetTag("lock_key", p.key)
+	p.log(ctx, "locking key: %d for repo: %s, pr: %d", p.key, p.repo, p.pr)
 	lock, err := p.lp.New(ctx, p.key, p.event)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to instantiate a preemptable lock")

--- a/pkg/locker/locker.go
+++ b/pkg/locker/locker.go
@@ -155,7 +155,6 @@ func (p *PreemptiveLocker) startSpanFromContext(ctx context.Context, operationNa
 	}
 
 	span, ctx := tracer.StartSpanFromContext(ctx, operationName, tracer.ServiceName(p.conf.tracingServiceName))
-	span.SetTag("lock_key", p.key)
 	span.SetTag("event", p.event)
 	return span, ctx
 }
@@ -184,6 +183,7 @@ func (p *PreemptiveLocker) Lock(ctx context.Context) (ch <-chan NotificationPayl
 	}
 
 	p.key = key
+	span.SetTag("lock_key", p.key)
 	lock, err := p.lp.New(ctx, p.key, p.event)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to instantiate a preemptable lock")

--- a/pkg/locker/locker.go
+++ b/pkg/locker/locker.go
@@ -202,8 +202,8 @@ func (p *PreemptiveLocker) Lock(ctx context.Context) (ch <-chan NotificationPayl
 
 	// Wait for the specified LockDelay before returning
 	select {
-	case <-ch:
-		return nil, ErrLockPreempted
+	case np := <-ch:
+		return nil, errors.Wrap(ErrLockPreempted, np.Message)
 	case <-time.After(p.conf.lockDelay):
 		return ch, nil
 	}


### PR DESCRIPTION
* Fixes issue where LockKey was just returning default value for int64 and not reporting errors properly
* Fixes issues with tests to determine if errors are not being reported and if we see a default value for int64. We could instead switch the return type of LockKey to `(*int64, error)` to differentiate between nil and the default value, but that seems a bit clunky to use. 
