### PR TITLE
locker: fix issue when preempted while waiting for lock

### DIFF
--- a/pkg/locker/locker.go
+++ b/pkg/locker/locker.go
@@ -202,7 +202,6 @@ func (p *PreemptiveLocker) Lock(ctx context.Context) (ch <-chan NotificationPayl
 	}
 
 	select {
-	// TODO (mk): Might be simpler to just let the user recognize that this operation has already been preempted, since they will be reading from the channel anyways.
 	case np := <-ch:
 		releaseCtx, cancel := context.WithTimeout(context.Background(), p.conf.lockWait)
 		releaseErr := p.Release(releaseCtx)


### PR DESCRIPTION
Noticed an issue with the PreemptiveLocker when the lock was preempted while waiting for the lock delay. 

Since users will typically only do a `defer pl.Release(ctx)` if no error is returned from `pl.Lock(ctx)`, I think it makes sense to Release on behalf of the user in this scenario. 

Although, thinking more about it, I think it would probably just make sense to not even return this error, but to instead just return the channel. The user will then use the same logic to determine when to preempt as if it was done later on in the operation. 