### PR TITLE
Set status timeout

### DIFF
--- a/pkg/persistence/pg.go
+++ b/pkg/persistence/pg.go
@@ -284,7 +284,9 @@ func (p *PGLayer) GetQAEnvironmentsByUser(ctx context.Context, user string) ([]Q
 }
 
 // SetQAEnvironmentStatus sets a specific QAEnvironment's status.
-// Note that this will bail if the context was canceled. It is often recommended to pass the background context to this function.
+// This method is unique in that callers often call this in cases where a root operation context is likely to be canceled.
+// Because of this, it often makes sense to pass the background context, or a newly created child of the background context, to this function.
+// For convenience, we set a default operation timeout to make sure that even if the caller passed the background context, we can prevent this function from waiting indefinitely.
 func (p *PGLayer) SetQAEnvironmentStatus(ctx context.Context, name string, status EnvironmentStatus) error {
 	if isCancelled(ctx) {
 		return errors.Wrap(ctx.Err(), "error setting qa environment status")


### PR DESCRIPTION
We had previously made a change where we updated callers of `SetQAEnvironmentStatus` to pass in the background context. This was in response to an issue where the status would not be updated when operations failed or were preempted, since the context would often be canceled and prevent that status call from actually behaving as expected.

However, I just saw an issue where the `SetQAEnvironmentStatus` function hung, and now recognize that perhaps we should have a proper timeout set for this call. 

The particular issue I saw resulted in:
1. The environment being stuck in the status of "Pending"
2. The lock never getting released since `Release(ctx)` was never called. 

So this prevented subsequent events (e.g. closing the PR) from being able to obtain the lock and clean up the environment. 

My proposal is to just add a timeout from within the function itself. This way, callers can still have the convenience of just passing in a background context (if they would like), without having to worry about the operation potentially hanging forever. 