### PR TITLE
fix: issue 116, create safeguards to release lock

### DIFF
--- a/acyl.yml
+++ b/acyl.yml
@@ -11,20 +11,20 @@ application:
   value_overrides:
     - "app.ui.enforce_oauth=true"
 # uncomment to disable traefik ingress
-#    - "ingress.traefik.enabled=false"
+    - "ingress.traefik.enabled=false"
 # uncomment to use in-environment Furan
-#    - "app.furan_addr=furan:4001"
-#    - "image.pullPolicy=IfNotPresent"
+    - "app.furan_addr=furan:4001"
+    - "image.pullPolicy=IfNotPresent"
 # local:
-#    - "app.dogstatsd_addr=1.2.3.4:8125"
-#    - "app.secrets_backend=env"
-#    - "app.secrets_mapping=ACYL_{{ .ID }}"
-#    - "app.secrets_from_env=true"
-#    - "app.k8s_secret_injections="
-#    - "app.operation_timeout_override=10m"
-#    - "app.k8s_secret_injections=image-pull-secret=k8s/image_pull_secret"
-#    - "app.ui_base_url=http://192.168.64.10:4000"
-#    - "cronautoscaling.enabled=false"
+    - "app.dogstatsd_addr=1.2.3.4:8125"
+    - "app.secrets_backend=env"
+    - "app.secrets_mapping=ACYL_{{ .ID }}"
+    - "app.secrets_from_env=true"
+    - "app.k8s_secret_injections="
+    - "app.operation_timeout_override=10m"
+    - "app.k8s_secret_injections=image-pull-secret=k8s/image_pull_secret"
+    - "app.ui_base_url=http://192.168.64.10:4000"
+    - "cronautoscaling.enabled=false"
 
 dependencies:
   direct:

--- a/acyl.yml
+++ b/acyl.yml
@@ -11,20 +11,20 @@ application:
   value_overrides:
     - "app.ui.enforce_oauth=true"
 # uncomment to disable traefik ingress
-    - "ingress.traefik.enabled=false"
+#    - "ingress.traefik.enabled=false"
 # uncomment to use in-environment Furan
-    - "app.furan_addr=furan:4001"
-    - "image.pullPolicy=IfNotPresent"
+#    - "app.furan_addr=furan:4001"
+#    - "image.pullPolicy=IfNotPresent"
 # local:
-    - "app.dogstatsd_addr=1.2.3.4:8125"
-    - "app.secrets_backend=env"
-    - "app.secrets_mapping=ACYL_{{ .ID }}"
-    - "app.secrets_from_env=true"
-    - "app.k8s_secret_injections="
-    - "app.operation_timeout_override=10m"
-    - "app.k8s_secret_injections=image-pull-secret=k8s/image_pull_secret"
-    - "app.ui_base_url=http://192.168.64.10:4000"
-    - "cronautoscaling.enabled=false"
+#    - "app.dogstatsd_addr=1.2.3.4:8125"
+#    - "app.secrets_backend=env"
+#    - "app.secrets_mapping=ACYL_{{ .ID }}"
+#    - "app.secrets_from_env=true"
+#    - "app.k8s_secret_injections="
+#    - "app.operation_timeout_override=10m"
+#    - "app.k8s_secret_injections=image-pull-secret=k8s/image_pull_secret"
+#    - "app.ui_base_url=http://192.168.64.10:4000"
+#    - "cronautoscaling.enabled=false"
 
 dependencies:
   direct:

--- a/cmd/integration.go
+++ b/cmd/integration.go
@@ -281,13 +281,11 @@ func setupNitro(dl persistence.DataLayer, useGHToken bool) (spawner.EnvironmentS
 	rc := ghclient.NewGitHubClient(ghtkn)
 	ng := &namegen.FakeNameGenerator{Unique: true}
 	mc := &metrics.FakeCollector{}
-	lp, err := locker.NewLockProvider(locker.FakeLockProviderKind, locker.WithLockWait(1*time.Second))
+	plf, err := locker.NewFakePreemptiveLockerFactory([]locker.LockProviderOption{
+		locker.WithLockTimeout(1 * time.Second),
+	})
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "error creating lock provider")
-	}
-	plf, err := locker.NewPreemptiveLockerFactory(lp)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "error creating preemptive locker factory")
+		return nil, nil, errors.Wrap(err, "unable to create new fake preeemptive locker factory")
 	}
 	nf := func(lf func(string, ...interface{}), notifications models.Notifications, user string) notifier.Router {
 		sb := &notifier.SlackBackend{

--- a/cmd/integration.go
+++ b/cmd/integration.go
@@ -281,7 +281,11 @@ func setupNitro(dl persistence.DataLayer, useGHToken bool) (spawner.EnvironmentS
 	rc := ghclient.NewGitHubClient(ghtkn)
 	ng := &namegen.FakeNameGenerator{Unique: true}
 	mc := &metrics.FakeCollector{}
-	plf, err := locker.NewPreemptiveLockerFactory(locker.NewFakeLockProvider())
+	lp, err := locker.NewLockProvider(locker.FakeLockProviderKind, locker.WithLockWait(1*time.Second))
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error creating lock provider")
+	}
+	plf, err := locker.NewPreemptiveLockerFactory(lp)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error creating preemptive locker factory")
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -160,7 +160,7 @@ func server(cmd *cobra.Command, args []string) {
 		log.Fatalf("error opening wordnet file: %v", err)
 	}
 
-	lp, err := locker.NewPostgresLockProvider(pgConfig.PostgresURI, datadogServiceName+".postgres_locker", pgConfig.EnableTracing)
+	lp, err := locker.NewLockProvider(locker.PostgresLockProviderKind, locker.WithPostgresBackend(pgConfig.PostgresURI, pgConfig.EnableTracing, datadogServiceName+".postgres_locker"))
 	if err != nil {
 		log.Fatalf("error creating Postgres lock provider: %v", err)
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -160,12 +160,12 @@ func server(cmd *cobra.Command, args []string) {
 		log.Fatalf("error opening wordnet file: %v", err)
 	}
 
-	lp, err := locker.NewLockProvider(locker.PostgresLockProviderKind, locker.WithPostgresBackend(pgConfig.PostgresURI, pgConfig.EnableTracing, datadogServiceName+".postgres_locker"))
+	lp, err := locker.NewLockProvider(locker.PostgresLockProviderKind, locker.WithPostgresBackend(pgConfig.PostgresURI, datadogServiceName+".postgres_locker"))
 	if err != nil {
 		log.Fatalf("error creating Postgres lock provider: %v", err)
 	}
 
-	plf, err := locker.NewPreemptiveLockerFactory(lp, locker.WithTracingEnabled(true), locker.WithTracingServiceName("postgres_lock"))
+	plf, err := locker.NewPreemptiveLockerFactory(lp, locker.WithAPMServiceName(datadogServiceName+".postgres_locker"))
 	if err != nil {
 		log.Fatalf("error creating preemptive locker factory: %v", err)
 	}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -370,11 +370,9 @@ func testConfigSetup(dl persistence.DataLayer) (*nitroenv.Manager, context.Conte
 		return nil, nil, nil, errors.Wrap(err, "error getting name generator")
 	}
 	mc := &metrics.FakeCollector{}
-	lp, err := locker.NewLockProvider(locker.FakeLockProviderKind)
-	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, "error creating lock provider")
-	}
-	plf, err := locker.NewPreemptiveLockerFactory(lp)
+	plf, err := locker.NewFakePreemptiveLockerFactory([]locker.LockProviderOption{
+		locker.WithLockTimeout(1 * time.Second),
+	})
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error creating preemptive locker factory")
 	}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -370,7 +370,11 @@ func testConfigSetup(dl persistence.DataLayer) (*nitroenv.Manager, context.Conte
 		return nil, nil, nil, errors.Wrap(err, "error getting name generator")
 	}
 	mc := &metrics.FakeCollector{}
-	plf, err := locker.NewPreemptiveLockerFactory(locker.NewFakeLockProvider())
+	lp, err := locker.NewLockProvider(locker.FakeLockProviderKind)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "error creating lock provider")
+	}
+	plf, err := locker.NewPreemptiveLockerFactory(lp)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error creating preemptive locker factory")
 	}
@@ -440,9 +444,9 @@ func runUI(dl persistence.DataLayer, nitromgr *nitroenv.Manager, repo string) (*
 		return nil, fmt.Errorf("unexpected type for ChartInstaller: %T", nitromgr.CI)
 	}
 	deps := &api.Dependencies{
-		DataLayer:    dl,
-		ServerConfig: serverConfig,
-		Logger:       uilogger,
+		DataLayer:          dl,
+		ServerConfig:       serverConfig,
+		Logger:             uilogger,
 		EnvironmentSpawner: nitromgr,
 		KubernetesReporter: ci,
 	}

--- a/pkg/locker/fake_lock.go
+++ b/pkg/locker/fake_lock.go
@@ -3,6 +3,7 @@ package locker
 import (
 	"context"
 	"fmt"
+	"log"
 	"math/rand"
 	"sync"
 	"time"
@@ -184,6 +185,7 @@ func (fpl *FakePreemptableLock) handleNotification(np NotificationPayload) {
 	case fpl.preempt <- np:
 		return
 	case <-time.After(fpl.conf.preemptionTimeout):
+		log.Printf("fake preemptable lock: preemption timeout reached (%v), unlocking", fpl.conf.preemptionTimeout)
 		fpl.Unlock(context.Background())
 	}
 }

--- a/pkg/locker/lock_test.go
+++ b/pkg/locker/lock_test.go
@@ -275,7 +275,7 @@ func testMaxLockDuration(t *testing.T, lp LockProvider) {
 		t.Fatalf("error locking lock: %v", err)
 	}
 
-	// Lock holder never unlocked explicitly, but the lock should have been unlocked automatically after the forceUnlock period has passed
+	// Lock holder never unlocked explicitly, but the lock should have been unlocked automatically after the maxLockDuration has passed
 	time.Sleep(2 * time.Second)
 	lock, err = lp.New(context.Background(), key, "some-event")
 	if err != nil {
@@ -304,7 +304,7 @@ func testPreemptionTimeout(t *testing.T, lp LockProvider) {
 		t.Fatalf("unable to acquire lock: %v", err)
 	}
 
-	// After waiting for a forcePreemption period, the lock should automatically be unlocked.
+	// After waiting for a preemptionTimeout, the lock should automatically be unlocked.
 	// So we should be able to lock.
 	lock2.Notify(context.Background())
 	time.Sleep(5 * time.Second)

--- a/pkg/locker/lock_test.go
+++ b/pkg/locker/lock_test.go
@@ -95,27 +95,27 @@ func runPreemptableLockTests(t *testing.T, lpFunc lpFactoryFunc) {
 		{
 			name:    "lock and unlock",
 			tfunc:   testLockAndUnlock,
-			options: []LockProviderOption{WithLockWait(5 * time.Second)},
+			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
 		},
 		{
 			name:    "preememption",
 			tfunc:   testPreemption,
-			options: []LockProviderOption{WithLockWait(time.Second)},
+			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
 		},
 		{
 			name:    "obtains correct lock key with concurrent goroutines",
 			tfunc:   testLockKeyConcurrent,
-			options: []LockProviderOption{WithLockWait(time.Second)},
+			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
 		},
 		{
 			name:    "force unlock is respected",
 			tfunc:   testForceUnlock,
-			options: []LockProviderOption{WithForceUnlock(2 * time.Second), WithLockWait(time.Second)},
+			options: []LockProviderOption{WithForceUnlock(2 * time.Second), WithLockWait(defaultPostgresLockWaitTime)},
 		},
 		{
 			name:    "force preemption is respected",
 			tfunc:   testForcePreemption,
-			options: []LockProviderOption{WithForcePreemption(1 * time.Second), WithLockWait(5 * time.Second)},
+			options: []LockProviderOption{WithForcePreemption(1 * time.Second), WithLockWait(defaultPostgresLockWaitTime)},
 		},
 	}
 

--- a/pkg/locker/lock_test.go
+++ b/pkg/locker/lock_test.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var testpostgresURI = "postgres://acyl:acyl@localhost:5432/acyl?sslmode=disable"
+var testPostgresURI = "postgres://acyl:acyl@localhost:5432/acyl?sslmode=disable"
 
 type testTableCoordinator struct {
 	db *sql.DB
@@ -36,7 +36,7 @@ func (ttc *testTableCoordinator) destroy() error {
 }
 
 func (ttc *testTableCoordinator) setup() error {
-	db, err := sql.Open("postgres", testpostgresURI)
+	db, err := sql.Open("postgres", testPostgresURI)
 	if err != nil {
 		return errors.Wrap(err, "error creating postgres connection")
 	}
@@ -53,8 +53,8 @@ func (ttc *testTableCoordinator) setup() error {
 }
 
 func TestFakePreemptableLock(t *testing.T) {
-	runPreemptableLockTests(t, func(t *testing.T) LockProvider {
-		return NewFakeLockProvider()
+	runPreemptableLockTests(t, func(t *testing.T, options ...LockProviderOption) (LockProvider, error) {
+		return NewLockProvider(FakeLockProviderKind, options...)
 	})
 }
 
@@ -72,38 +72,50 @@ func TestPostgresPreemptableLock(t *testing.T) {
 			t.Logf("error destroying tables: %v", err)
 		}
 	}()
-	runPreemptableLockTests(t, func(t *testing.T) LockProvider {
-		pl, err := NewPostgresLockProvider(testpostgresURI, "postgres_locker", false)
-		if err != nil {
-			t.Fatalf("unable to create postgres lock provider: %v", err)
-		}
-		return pl
+	runPreemptableLockTests(t, func(t *testing.T, options ...LockProviderOption) (LockProvider, error) {
+		opts := []LockProviderOption{WithPostgresBackend(testPostgresURI, false, "")}
+		opts = append(opts, options...)
+		return NewLockProvider(PostgresLockProviderKind, opts...)
 	})
 }
 
-// pLFactoryFunc is a function that returns an empty Preemptable Locker
-type pLFactoryFunc func(t *testing.T) LockProvider
+// lockProviderFactoryFunc is a test helper function for creating LockProviders
+type lpFactoryFunc func(t *testing.T, options ...LockProviderOption) (LockProvider, error)
 
 // runPreemptableLockTests runs all tests against the LockProvider implementation returned by plfunc
-func runPreemptableLockTests(t *testing.T, plfunc pLFactoryFunc) {
-	if plfunc == nil {
+func runPreemptableLockTests(t *testing.T, lpFunc lpFactoryFunc) {
+	if lpFunc == nil {
 		t.Fatalf("plfunc cannot be nil")
 	}
 	tests := []struct {
-		name  string
-		tfunc func(*testing.T, LockProvider)
+		name    string
+		tfunc   func(*testing.T, LockProvider)
+		options []LockProviderOption
 	}{
 		{
-			name:  "lock and unlock",
-			tfunc: testLockAndUnlock,
+			name:    "lock and unlock",
+			tfunc:   testLockAndUnlock,
+			options: []LockProviderOption{WithLockWait(5 * time.Second)},
 		},
 		{
-			name:  "preememption",
-			tfunc: testPreemption,
+			name:    "preememption",
+			tfunc:   testPreemption,
+			options: []LockProviderOption{WithLockWait(time.Second)},
 		},
 		{
-			name:  "obtains correct lock key with concurrent goroutines",
-			tfunc: testLockKeyConcurrent,
+			name:    "obtains correct lock key with concurrent goroutines",
+			tfunc:   testLockKeyConcurrent,
+			options: []LockProviderOption{WithLockWait(time.Second)},
+		},
+		{
+			name:    "force unlock is respected",
+			tfunc:   testForceUnlock,
+			options: []LockProviderOption{WithForceUnlock(2 * time.Second), WithLockWait(time.Second)},
+		},
+		{
+			name:    "force preemption is respected",
+			tfunc:   testForcePreemption,
+			options: []LockProviderOption{WithForcePreemption(1 * time.Second), WithLockWait(5 * time.Second)},
 		},
 	}
 
@@ -112,7 +124,11 @@ func runPreemptableLockTests(t *testing.T, plfunc pLFactoryFunc) {
 			if tt.tfunc == nil {
 				t.Skip("test func is nil")
 			}
-			tt.tfunc(t, plfunc(t))
+			pl, err := lpFunc(t, tt.options...)
+			if err != nil {
+				t.Fatalf("error creating lock provdier")
+			}
+			tt.tfunc(t, pl)
 		})
 	}
 }
@@ -123,16 +139,13 @@ func testLockAndUnlock(t *testing.T, lp LockProvider) {
 	if err != nil {
 		t.Fatalf("unable to acquire lock: %v", err)
 	}
-	preempt, err := lock.Lock(context.Background(), 5*time.Second)
+	preempt, err := lock.Lock(context.Background())
 
 	if err != nil {
 		t.Fatalf("unable to lock: %v", err)
 	}
 	defer func() {
-		err := lock.Unlock(context.Background())
-		if err != nil {
-			t.Fatalf("error unlocking: %v", err)
-		}
+		lock.Unlock(context.Background())
 	}()
 
 	newLock, err := lp.New(context.Background(), key, "new-event")
@@ -141,7 +154,7 @@ func testLockAndUnlock(t *testing.T, lp LockProvider) {
 	}
 
 	// lock is already acquired. new locks should not be able to lock on the same key
-	_, err = newLock.Lock(context.Background(), time.Second)
+	_, err = newLock.Lock(context.Background())
 	if err == nil {
 		t.Fatalf("expected error trying to lock")
 	}
@@ -166,7 +179,7 @@ func testPreemption(t *testing.T, lp LockProvider) {
 		t.Fatalf("unable to acquire lock: %v", err)
 	}
 
-	preempt, err := lock.Lock(context.Background(), time.Second)
+	preempt, err := lock.Lock(context.Background())
 	if err != nil {
 		t.Fatalf("unable to lock: %v", err)
 	}
@@ -179,23 +192,17 @@ func testPreemption(t *testing.T, lp LockProvider) {
 
 	select {
 	case <-preempt:
-		err := lock.Unlock(context.Background())
-		if err != nil {
-			t.Fatalf("error unlocking: %v", err)
-		}
+		lock.Unlock(context.Background())
 	case <-time.After(time.Second):
 		t.Fatalf("lock was never preempted after being notified")
 	}
 
 	// Now, the second lock should be able to lock
-	_, err = lock2.Lock(context.Background(), time.Second)
+	_, err = lock2.Lock(context.Background())
 	if err != nil {
 		t.Fatalf("unable to lock: %v", err)
 	}
-	err = lock2.Unlock(context.Background())
-	if err != nil {
-		t.Fatalf("error unlocking: %v", err)
-	}
+	lock2.Unlock(context.Background())
 }
 
 func testContextCancellation(t *testing.T, lp LockProvider) {
@@ -213,7 +220,7 @@ func testContextCancellation(t *testing.T, lp LockProvider) {
 	}
 
 	cancel()
-	_, err = lock.Lock(ctx, time.Second)
+	_, err = lock.Lock(ctx)
 	if err == nil {
 		t.Fatalf("expected canceled context to prevent the ability to lock the lock")
 	}
@@ -254,5 +261,56 @@ func testLockKeyConcurrent(t *testing.T, lp LockProvider) {
 		if first != key {
 			t.Fatalf("expected all keys to be the same. 2 differ: %d, %d", first, key)
 		}
+	}
+}
+
+func testForceUnlock(t *testing.T, lp LockProvider) {
+	key := rand.Int63()
+	lock, err := lp.New(context.Background(), key, "some-event")
+	if err != nil {
+		t.Fatalf("unable to acquire lock: %v", err)
+	}
+	_, err = lock.Lock(context.Background())
+	if err != nil {
+		t.Fatalf("error locking lock: %v", err)
+	}
+
+	// Lock holder never unlocked explicitly, but the lock should have been unlocked automatically after the forceUnlock period has passed
+	time.Sleep(2 * time.Second)
+	lock, err = lp.New(context.Background(), key, "some-event")
+	if err != nil {
+		t.Fatalf("unable to acquire lock: %v", err)
+	}
+
+	_, err = lock.Lock(context.Background())
+	if err != nil {
+		t.Fatalf("error locking lock: %v", err)
+	}
+}
+
+func testForcePreemption(t *testing.T, lp LockProvider) {
+	key := rand.Int63()
+	lock, err := lp.New(context.Background(), key, "some-event")
+	if err != nil {
+		t.Fatalf("unable to acquire lock: %v", err)
+	}
+	_, err = lock.Lock(context.Background())
+	if err != nil {
+		t.Fatalf("error locking lock: %v", err)
+	}
+
+	lock2, err := lp.New(context.Background(), key, "some-event")
+	if err != nil {
+		t.Fatalf("unable to acquire lock: %v", err)
+	}
+
+	// After waiting for a forcePreemption period, the lock should automatically be unlocked.
+	// So we should be able to lock.
+	lock2.Notify(context.Background())
+	time.Sleep(2 * time.Second)
+
+	_, err = lock2.Lock(context.Background())
+	if err != nil {
+		t.Fatalf("error locking lock: %v", err)
 	}
 }

--- a/pkg/locker/locker.go
+++ b/pkg/locker/locker.go
@@ -76,8 +76,11 @@ type LockProvider interface {
 type LockProviderKind int
 
 const (
+	// UnknownLockProviderKind is the default kind and is unimplmeneted
+	UnknownLockProviderKind = iota
+
 	// PostgresLockProviderKind represents an implementation of the LockProvider interface that uses Postgres as the underlying store
-	PostgresLockProviderKind LockProviderKind = iota
+	PostgresLockProviderKind
 
 	// FakeLockProviderKind represents an implementation of the LockProvider interfaces that uses an in-memory store, suitable for tests
 	FakeLockProviderKind
@@ -110,6 +113,8 @@ func NewLockProvider(kind LockProviderKind, options ...LockProviderOption) (Lock
 		return newPostgresLockProvider(*config)
 	case FakeLockProviderKind:
 		return newFakeLockProvider(*config), nil
+	case UnknownLockProviderKind:
+		fallthrough
 	default:
 		return nil, fmt.Errorf("lock provider kind not implemented: %v", kind)
 	}

--- a/pkg/locker/locker.go
+++ b/pkg/locker/locker.go
@@ -2,6 +2,7 @@ package locker
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -12,15 +13,105 @@ import (
 	"github.com/pkg/errors"
 )
 
+type LockProviderConfig struct {
+	// lockWait is how long the lock will block before giving up
+	lockWait time.Duration
+
+	// forceUnlock is the duration in which the lock will wait before automatically getting unlocked, no matter what the holder does.
+	// This provides a fallback for ensuring the lock gets unlocked.
+	forceUnlock time.Duration
+
+	// forcePreemption is the duration in which the lock will wait for the holder to respect a notification and release the lock.
+	// If a notification is sent to the lock, the lock will be released after this duration no matter what the holder does.
+	// This provides a mechanism for releasing the lock quickly in scenarios where the holder of the lock may be blocked indefinitely.
+	forcePreemption time.Duration
+
+	// postgresURI is used to connect to Postgres for a Postgres Lock Provider
+	postgresURI string
+
+	// enableTracing will allow the lock to send traces when applicable
+	enableTracing bool
+
+	// apmServiceName is the service name the traces will use
+	apmServiceName string
+}
+
+type LockProviderOption func(*LockProviderConfig)
+
 var (
-	defaultLockWaitTime = (30 * time.Minute) + (30 * time.Second) // global async timeout is 30 minutes
-	defaultLockDelay    = 10 * time.Second
+	defaultForcePreemption = 10 * time.Second
+	defaultLockWait        = 20 * time.Second
+	defaultLockDelay       = 10 * time.Second
+	defaultForceUnlock     = 30*time.Minute + 30*time.Second // global async timeout is 30 minutes
 )
+
+func WithForceUnlock(duration time.Duration) LockProviderOption {
+	return func(config *LockProviderConfig) {
+		config.forceUnlock = duration
+	}
+}
+
+func WithForcePreemption(duration time.Duration) LockProviderOption {
+	return func(config *LockProviderConfig) {
+		config.forcePreemption = duration
+	}
+}
+
+func WithLockWait(lockWait time.Duration) LockProviderOption {
+	return func(config *LockProviderConfig) {
+		config.lockWait = lockWait
+	}
+}
+
+func WithPostgresBackend(postgresURI string, enableTracing bool, apmServiceName string) LockProviderOption {
+	return func(config *LockProviderConfig) {
+		config.postgresURI = postgresURI
+		config.apmServiceName = apmServiceName
+		config.enableTracing = enableTracing
+	}
+}
 
 // LockProvider describes an object capable of creating distributed locks. You may provide your own int64 key or obtain one for a given Repo/PR.
 type LockProvider interface {
 	New(ctx context.Context, key int64, event string) (PreemptableLock, error)
 	LockKey(ctx context.Context, repo string, pr uint) (int64, error)
+}
+
+type LockProviderKind int
+
+const (
+	PostgresLockProviderKind LockProviderKind = iota
+	FakeLockProviderKind
+)
+
+func NewLockProvider(kind LockProviderKind, options ...LockProviderOption) (LockProvider, error) {
+	config := &LockProviderConfig{}
+	for _, opt := range options {
+		opt(config)
+	}
+	if config.lockWait == 0 {
+		config.lockWait = defaultLockWait
+	}
+	if config.forceUnlock == 0 {
+		config.forceUnlock = defaultForceUnlock
+	}
+	if config.forcePreemption == 0 {
+		config.forcePreemption = defaultForcePreemption
+	}
+	if config.apmServiceName == "" {
+		config.apmServiceName = "lock_provider"
+	}
+	switch kind {
+	case PostgresLockProviderKind:
+		if config.postgresURI == "" {
+			return nil, errors.New("must provide postgres uri for postgres lock provider")
+		}
+		return newPostgresLockProvider(*config)
+	case FakeLockProviderKind:
+		return newFakeLockProvider(*config), nil
+	default:
+		return nil, fmt.Errorf("lock provider kind not implemented: %v", kind)
+	}
 }
 
 // NotificationPayload represents the content of messages sent to the lock holder.
@@ -33,7 +124,7 @@ type NotificationPayload struct {
 	Message string `json:"event"`
 
 	// The key that this Notification Payload pertains to
-	LockKey int64
+	LockKey int64 `json:lockKey`
 }
 
 // PreemptiveLocker represents a distributed lock where callers can be preempted while waiting for the lock to be released or while holding the lock. High level, the algorithm is as follows:
@@ -58,8 +149,8 @@ type PreemptiveLocker struct {
 // PreemptableLock describes an object that acts as a Lock that can signal to peers that they should unlock
 // Preemptable locks are single use. Once you unlock the lock, underlying resources will be cleaned up
 type PreemptableLock interface {
-	// Lock locks the preemptable lock. If it's unable to obtain the lock after that timeout period, it should return an error
-	Lock(ctx context.Context, lockWait time.Duration) (<-chan NotificationPayload, error)
+	// Lock locks the preemptable lock. If it fails to lock, or is preempted before locking, it should return an error
+	Lock(ctx context.Context) (<-chan NotificationPayload, error)
 
 	// Unlock unlocks the preemptable lock. It should clean up any underlying resources
 	Unlock(ctx context.Context) error
@@ -70,10 +161,8 @@ type PreemptableLock interface {
 
 // PreemptiveLockerConfig contains values for adjusting how the PreemptiveLocker behaves
 type PreemptiveLockerConfig struct {
-	// lockWait is how long a preemtive lock will block waiting for the lock to be acquired
-	lockWait time.Duration
 
-	// lockDelay is how long the locker should wait before attempting to acquire the lock
+	// lockDelay is how long the locker should wait before returning the lock
 	// This is an imperfect, but practical way of ensuring we don't perform operations before other lock holders have realized that their session has ended
 	lockDelay time.Duration
 
@@ -85,12 +174,6 @@ type PreemptiveLockerConfig struct {
 }
 
 type PreemptiveLockerOption func(*PreemptiveLockerConfig)
-
-func WithLockWait(lockWait time.Duration) PreemptiveLockerOption {
-	return func(config *PreemptiveLockerConfig) {
-		config.lockWait = lockWait
-	}
-}
 
 func WithLockDelay(lockDelay time.Duration) PreemptiveLockerOption {
 	return func(config *PreemptiveLockerConfig) {
@@ -123,9 +206,6 @@ func NewPreemptiveLockerFactory(provider LockProvider, opts ...PreemptiveLockerO
 	config := PreemptiveLockerConfig{}
 	for _, opt := range opts {
 		opt(&config)
-	}
-	if config.lockWait == 0 {
-		config.lockWait = defaultLockWaitTime
 	}
 	if config.lockDelay == 0 {
 		config.lockDelay = defaultLockDelay
@@ -196,19 +276,17 @@ func (p *PreemptiveLocker) Lock(ctx context.Context) (ch <-chan NotificationPayl
 		return nil, errors.Wrap(err, "unable to notify other locks")
 	}
 
-	ch, err = lock.Lock(ctx, p.conf.lockWait)
+	ch, err = lock.Lock(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to lock")
 	}
 
 	select {
 	case np := <-ch:
-		releaseCtx, cancel := context.WithTimeout(context.Background(), p.conf.lockWait)
-		releaseErr := p.Release(releaseCtx)
+		releaseErr := p.Release(context.Background())
 		if releaseErr != nil {
 			p.log(ctx, "error releasing lock: %v", releaseErr)
 		}
-		cancel()
 		return nil, errors.Wrap(ErrLockPreempted, np.Message)
 	// Wait for the specified LockDelay before returning
 	case <-time.After(p.conf.lockDelay):
@@ -222,7 +300,6 @@ func (p *PreemptiveLocker) Release(ctx context.Context) (err error) {
 	defer func() {
 		span.Finish(tracer.WithError(err))
 	}()
-
 	if p.lock == nil {
 		return errors.New("attempting to Release before the lock has been locked")
 	}

--- a/pkg/locker/locker_test.go
+++ b/pkg/locker/locker_test.go
@@ -29,7 +29,7 @@ func TestPostgresPreemptiveLocker(t *testing.T) {
 		}
 	}()
 	runPreemptiveLockerTests(t, func(t *testing.T, options ...LockProviderOption) (LockProvider, error) {
-		opts := []LockProviderOption{WithPostgresBackend(testPostgresURI, false, "")}
+		opts := []LockProviderOption{WithPostgresBackend(testPostgresURI, "")}
 		opts = append(opts, options...)
 		return NewLockProvider(PostgresLockProviderKind, opts...)
 	})
@@ -57,22 +57,22 @@ func runPreemptiveLockerTests(t *testing.T, lpFunc lpFactoryFunc) {
 		{
 			name:    "locking more than once should return an error",
 			tfunc:   testPreemptiveLockerLocksOnlyOnce,
-			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
+			options: []LockProviderOption{WithLockTimeout(defaultPostgresLockWaitTime)},
 		},
 		{
 			name:    "lock and release",
 			tfunc:   testPreemptiveLockerLockAndRelease,
-			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
+			options: []LockProviderOption{WithLockTimeout(defaultPostgresLockWaitTime)},
 		},
 		{
 			name:    "configurable lock delay",
 			tfunc:   testPreemptiveLockerLockDelay,
-			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
+			options: []LockProviderOption{WithLockTimeout(defaultPostgresLockWaitTime)},
 		},
 		{
 			name:    "new preemptive locker should respect canceled context",
 			tfunc:   testNewPreemptiveLockerCancelledContext,
-			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
+			options: []LockProviderOption{WithLockTimeout(defaultPostgresLockWaitTime)},
 		},
 	}
 

--- a/pkg/locker/locker_test.go
+++ b/pkg/locker/locker_test.go
@@ -65,12 +65,14 @@ func runPreemptiveLockerTests(t *testing.T, lpFunc lpFactoryFunc) {
 			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
 		},
 		{
-			name:  "configurable lock delay",
-			tfunc: testPreemptiveLockerLockDelay,
+			name:    "configurable lock delay",
+			tfunc:   testPreemptiveLockerLockDelay,
+			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
 		},
 		{
-			name:  "new preemptive locker should respect canceled context",
-			tfunc: testNewPreemptiveLockerCancelledContext,
+			name:    "new preemptive locker should respect canceled context",
+			tfunc:   testNewPreemptiveLockerCancelledContext,
+			options: []LockProviderOption{WithLockWait(defaultPostgresLockWaitTime)},
 		},
 	}
 

--- a/pkg/locker/postgres_lock.go
+++ b/pkg/locker/postgres_lock.go
@@ -113,9 +113,11 @@ type PostgresLock struct {
 
 	// message represents a descriptive reason to communicate to other lock holders why their operation was preempted, optional
 	message string
+
+	conf LockProviderConfig
 }
 
-func NewPostgresLock(ctx context.Context, db *sqlx.DB, key int64, connInfo, message string) (pl *PostgresLock, err error) {
+func NewPostgresLock(ctx context.Context, db *sqlx.DB, key int64, connInfo, message string, conf LockProviderConfig) (pl *PostgresLock, err error) {
 	id, err := uuid.NewUUID()
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create new UUID")
@@ -147,6 +149,7 @@ func NewPostgresLock(ctx context.Context, db *sqlx.DB, key int64, connInfo, mess
 		postgresURI: connInfo,
 		preempted:   make(chan NotificationPayload, 1),
 		message:     message,
+		conf:        conf,
 	}
 	return pl, nil
 }
@@ -159,24 +162,24 @@ func (pl *PostgresLock) handleEvents(ctx context.Context, listener *pq.Listener)
 	for {
 		select {
 		case <-ctx.Done():
-			pl.preempted <- NotificationPayload{
+			pl.handleNotification(NotificationPayload{
 				ID:      pl.id,
 				Message: ctx.Err().Error(),
 				LockKey: pl.key,
-			}
+			})
 			return
 		case err := <-pl.psc.sessionErr:
 			if err != nil {
-				pl.preempted <- NotificationPayload{
+				pl.handleNotification(NotificationPayload{
 					ID:      pl.id,
 					Message: err.Error(),
 					LockKey: pl.key,
-				}
+				})
 			}
 			return
 		case notification := <-listener.Notify:
 			if notification == nil {
-				pl.log(ctx, "received nil notiifcation")
+				pl.log(ctx, "received nil notification")
 				return
 			}
 			payload := notification.Extra
@@ -186,21 +189,27 @@ func (pl *PostgresLock) handleEvents(ctx context.Context, listener *pq.Listener)
 				// In the event that we receive an unknown notification payload, we will give up the lock.
 				// This could help for debugging since we can execute a Notify query to force the app to release the lock.
 				// It could also help if we accidentally make a breaking change to the Notification payload.
-				pl.preempted <- NotificationPayload{
+				pl.handleNotification(NotificationPayload{
 					ID:      pl.id,
 					Message: "received unknown notification payload",
 					LockKey: pl.key,
-				}
+				})
 				return
 			}
 
 			// If we have received a notification that is not our own, send it over the channel and return
 			if np.ID != pl.id {
-				pl.preempted <- np
+				pl.handleNotification(np)
 				return
 			}
 		}
 	}
+}
+
+func (pl *PostgresLock) handleNotification(np NotificationPayload) {
+	go func() { pl.preempted <- np }()
+	time.Sleep(pl.conf.forcePreemption)
+	pl.Unlock(context.Background())
 }
 
 // Notify lets other processes know that they should release the lock.
@@ -224,6 +233,7 @@ func (pl *PostgresLock) Notify(ctx context.Context) error {
 	return nil
 }
 
+// Unlock is an idempotent method.
 func (pl *PostgresLock) Unlock(ctx context.Context) error {
 	defer func() {
 		// Even if we fail to unlock via Postgres properly, destroying the lock should close the underlying sql.Conn.
@@ -243,24 +253,15 @@ func (pl *PostgresLock) Unlock(ctx context.Context) error {
 	return nil
 }
 
-func (pl *PostgresLock) Lock(ctx context.Context, lockWait time.Duration) (<-chan NotificationPayload, error) {
-	query := `SELECT pg_advisory_lock($1)`
-	advLockContext, cancel := context.WithTimeout(ctx, lockWait)
-	defer cancel()
-	_, err := pl.conn.ExecContext(advLockContext, query, pl.key)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to create pg advisory lock")
-	}
-
+func (pl *PostgresLock) Lock(ctx context.Context) (<-chan NotificationPayload, error) {
 	handleEvents := func(event pq.ListenerEventType, err error) {
-		// TODO (mk): Reconsider how we want to handle these events after we have enough usage
 		if err != nil {
 			pl.log(ctx, "received error when handling postgres listener event: %v", err)
 		}
 	}
 
 	listener := pq.NewListener(pl.postgresURI, 10*time.Second, time.Minute, handleEvents)
-	err = listener.Listen(notificationChannel(pl.key))
+	err := listener.Listen(notificationChannel(pl.key))
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to establish listener")
 	}
@@ -268,6 +269,19 @@ func (pl *PostgresLock) Lock(ctx context.Context, lockWait time.Duration) (<-cha
 	go func() {
 		pl.handleEvents(ctx, pl.listener)
 	}()
+
+	go func() {
+		time.Sleep(pl.conf.forceUnlock)
+		pl.Unlock(context.Background())
+	}()
+
+	query := `SELECT pg_advisory_lock($1)`
+	advLockContext, cancel := context.WithTimeout(ctx, pl.conf.lockWait)
+	defer cancel()
+	_, err = pl.conn.ExecContext(advLockContext, query, pl.key)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create pg advisory lock")
+	}
 
 	return pl.preempted, nil
 }
@@ -299,27 +313,28 @@ func (pl *PostgresLock) log(ctx context.Context, msg string, args ...interface{}
 type PostgresLockProvider struct {
 	db       *sqlx.DB
 	connInfo string
+	conf     LockProviderConfig
 }
 
-// NewPostgresLockProvider returns a PostgresLockProvider, which implements the LockProvider interface
+// newPostgresLock returns a PostgresLockProvider, which implements the LockProvider interface
 // It utilizes advisory locks and Notify / Listen in order to provide PreemptableLocks
-func NewPostgresLockProvider(postgresURI, datadogServiceName string, enableTracing bool) (*PostgresLockProvider, error) {
+func newPostgresLockProvider(conf LockProviderConfig) (*PostgresLockProvider, error) {
 	var db *sqlx.DB
 	var err error
-	if enableTracing {
-		sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName(datadogServiceName))
-		db, err = sqlxtrace.Open("postgres", postgresURI)
+	if conf.enableTracing {
+		sqltrace.Register("postgres", &pq.Driver{}, sqltrace.WithServiceName(conf.apmServiceName))
+		db, err = sqlxtrace.Open("postgres", conf.postgresURI)
 	} else {
-		db, err = sqlx.Open("postgres", postgresURI)
+		db, err = sqlx.Open("postgres", conf.postgresURI)
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "error opening db")
 	}
-	return &PostgresLockProvider{db: db, connInfo: postgresURI}, nil
+	return &PostgresLockProvider{db: db, connInfo: conf.postgresURI, conf: conf}, nil
 }
 
 func (plp *PostgresLockProvider) New(ctx context.Context, key int64, event string) (PreemptableLock, error) {
-	return NewPostgresLock(ctx, plp.db, key, plp.connInfo, event)
+	return NewPostgresLock(ctx, plp.db, key, plp.connInfo, event, plp.conf)
 }
 
 // PostgresEnvLock models a distributed lock associated with a unique repo/PR combination

--- a/pkg/locker/postgres_lock_test.go
+++ b/pkg/locker/postgres_lock_test.go
@@ -65,8 +65,8 @@ func TestPostgresContextCancelationDetection(t *testing.T) {
 		t.Skip()
 	}
 	opts := []LockProviderOption{
-		WithPostgresBackend(testPostgresURI, false, ""),
-		WithLockWait(time.Second),
+		WithPostgresBackend(testPostgresURI, ""),
+		WithLockTimeout(time.Second),
 	}
 	lp, err := NewLockProvider(PostgresLockProviderKind, opts...)
 	if err != nil {

--- a/pkg/locker/postgres_lock_test.go
+++ b/pkg/locker/postgres_lock_test.go
@@ -16,16 +16,16 @@ func TestPostgresLockHandlesSessionError(t *testing.T) {
 		t.Skip()
 	}
 
-	db, err := sqlx.Open("postgres", testpostgresURI)
+	db, err := sqlx.Open("postgres", testPostgresURI)
 	if err != nil {
 		t.Fatalf("unable to open postgres connection: %v", err)
 	}
-	lock, err := NewPostgresLock(context.Background(), db, rand.Int63(), testpostgresURI, "some-event")
+	lock, err := NewPostgresLock(context.Background(), db, rand.Int63(), testPostgresURI, "some-event", LockProviderConfig{})
 	if err != nil {
 		t.Fatalf("unable to create postgres lock: %v", err)
 	}
 
-	preempt, err := lock.Lock(context.Background(), time.Second)
+	preempt, err := lock.Lock(context.Background())
 	if err != nil {
 		t.Fatalf("error locking postgres lock: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestPostgresLockProviderFailedInitialConnection(t *testing.T) {
 		t.Skip()
 	}
 
-	db, err := sqlx.Open("postgres", testpostgresURI)
+	db, err := sqlx.Open("postgres", testPostgresURI)
 	if err != nil {
 		t.Fatalf("unable to open postgres connection: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestPostgresLockProviderFailedInitialConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to close db")
 	}
-	_, err = NewPostgresLock(context.Background(), db, rand.Int63(), testpostgresURI, "some-event")
+	_, err = NewPostgresLock(context.Background(), db, rand.Int63(), testPostgresURI, "some-event", LockProviderConfig{})
 	if err == nil {
 		t.Fatalf("expected error when creating postgres lock with close sql.DB")
 	}
@@ -64,19 +64,23 @@ func TestPostgresContextCancelationDetection(t *testing.T) {
 	if os.Getenv("POSTGRES_ALREADY_RUNNING") == "" {
 		t.Skip()
 	}
-
-	db, err := sqlx.Open("postgres", testpostgresURI)
-	if err != nil {
-		t.Fatalf("unable to open postgres connection: %v", err)
+	opts := []LockProviderOption{
+		WithPostgresBackend(testPostgresURI, false, ""),
+		WithLockWait(time.Second),
 	}
+	lp, err := NewLockProvider(PostgresLockProviderKind, opts...)
+	if err != nil {
+		t.Fatalf("unable to create lock provider: %v", err)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	lock, err := NewPostgresLock(ctx, db, rand.Int63(), testpostgresURI, "some-event")
+	lock, err := lp.New(ctx, rand.Int63(), "some-event")
 	if err != nil {
 		t.Fatalf("unable to create postgres lock: %v", err)
 	}
 
-	preempt, err := lock.Lock(ctx, time.Second)
+	preempt, err := lock.Lock(ctx)
 	if err != nil {
 		t.Fatalf("error locking postgres lock: %v", err)
 	}
@@ -96,7 +100,7 @@ func TestPostgresLockNilDB(t *testing.T) {
 		t.Skip()
 	}
 
-	_, err := NewPostgresLock(context.Background(), nil, rand.Int63(), testpostgresURI, "some-event")
+	_, err := NewPostgresLock(context.Background(), nil, rand.Int63(), testPostgresURI, "some-event", LockProviderConfig{})
 	if err == nil {
 		t.Fatalf("expected error creating a postgres lock with no db")
 	}

--- a/pkg/locker/postgres_lock_test.go
+++ b/pkg/locker/postgres_lock_test.go
@@ -20,7 +20,11 @@ func TestPostgresLockHandlesSessionError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to open postgres connection: %v", err)
 	}
-	lock, err := NewPostgresLock(context.Background(), db, rand.Int63(), testPostgresURI, "some-event", LockProviderConfig{})
+	lock, err := NewPostgresLock(context.Background(), db, rand.Int63(), testPostgresURI, "some-event", LockProviderConfig{
+		preemptionTimeout: defaultPreemptionTimeout,
+		lockTimeout:       defaultLockTimeout,
+		maxLockDuration:   defaultMaxLockDuration,
+	})
 	if err != nil {
 		t.Fatalf("unable to create postgres lock: %v", err)
 	}

--- a/pkg/nitro/env/env.go
+++ b/pkg/nitro/env/env.go
@@ -238,6 +238,9 @@ func (m *Manager) lockingOperation(ctx context.Context, repo string, pr uint, f 
 			m.MC.Increment(mpfx+"lock_preempt", "triggering_repo:"+repo)
 			m.log(ctx, "operation preempted: %v: %v, %v", repo, pr, np)
 			eventlogger.GetLogger(ctx).SetCompletedStatus(models.FailedStatus)
+			releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			lock.Release(releaseCtx)
+			cancel()
 		case <-stop:
 		}
 		cf()

--- a/pkg/nitro/env/env.go
+++ b/pkg/nitro/env/env.go
@@ -253,7 +253,7 @@ func (m *Manager) lockingOperation(ctx context.Context, repo string, pr uint, f 
 	case opErr := <-ch:
 		err = opErr
 	case <-ctx.Done():
-		return
+		err = ctx.Err()
 	}
 	if err != nil {
 		eventlogger.GetLogger(ctx).SetCompletedStatus(models.FailedStatus)

--- a/pkg/nitro/env/env_test.go
+++ b/pkg/nitro/env/env_test.go
@@ -38,10 +38,16 @@ import (
 
 func TestLockingOperation(t *testing.T) {
 	el := &eventlogger.Logger{DL: persistence.NewFakeDataLayer()}
-	plf, err := locker.NewPreemptiveLockerFactory(
-		locker.NewFakeLockProvider(),
-		locker.WithLockDelay(time.Millisecond),
+	lp, err := locker.NewLockProvider(
+		locker.FakeLockProviderKind,
 		locker.WithLockWait(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("error creating new lock provider: %v", err)
+	}
+	plf, err := locker.NewPreemptiveLockerFactory(
+		lp,
+		locker.WithLockDelay(time.Millisecond),
 	)
 	if err != nil {
 		t.Fatalf("error creating new preemptive locker factory: %v", err)
@@ -472,10 +478,16 @@ func TestCreate(t *testing.T) {
 				KC: k8sfake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "nitro-1234-some-random-name"}}),
 			}
 			nt := newNotificationTracker()
-			plf, err := locker.NewPreemptiveLockerFactory(
-				locker.NewFakeLockProvider(),
-				locker.WithLockDelay(time.Second),
+			lp, err := locker.NewLockProvider(
+				locker.FakeLockProviderKind,
 				locker.WithLockWait(2*time.Second),
+			)
+			if err != nil {
+				t.Fatalf("error creating new lock provider: %v", err)
+			}
+			plf, err := locker.NewPreemptiveLockerFactory(
+				lp,
+				locker.WithLockDelay(time.Second),
 			)
 			if err != nil {
 				t.Fatalf("error creating new preemptive locker factory: %v", err)
@@ -743,10 +755,16 @@ func TestUpdate(t *testing.T) {
 				KC:           k8sfake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: c.inputK8sEnv.Namespace}}),
 			}
 			nt := newNotificationTracker()
-			plf, err := locker.NewPreemptiveLockerFactory(
-				locker.NewFakeLockProvider(),
-				locker.WithLockDelay(time.Millisecond),
+			lp, err := locker.NewLockProvider(
+				locker.FakeLockProviderKind,
 				locker.WithLockWait(time.Second),
+			)
+			if err != nil {
+				t.Fatalf("error creating new lock provider: %v", err)
+			}
+			plf, err := locker.NewPreemptiveLockerFactory(
+				lp,
+				locker.WithLockDelay(time.Millisecond),
 			)
 			if err != nil {
 				t.Fatalf("error creating new preemptive locker factory: %v", err)
@@ -909,10 +927,16 @@ func TestDelete(t *testing.T) {
 				DL:           dl,
 				HelmReleases: releases,
 			}
-			plf, err := locker.NewPreemptiveLockerFactory(
-				locker.NewFakeLockProvider(),
-				locker.WithLockDelay(time.Millisecond),
+			lp, err := locker.NewLockProvider(
+				locker.FakeLockProviderKind,
 				locker.WithLockWait(time.Second),
+			)
+			if err != nil {
+				t.Fatalf("error creating new lock provider: %v", err)
+			}
+			plf, err := locker.NewPreemptiveLockerFactory(
+				lp,
+				locker.WithLockDelay(time.Millisecond),
 			)
 			if err != nil {
 				t.Fatalf("error creating new preemptive locker factory: %v", err)

--- a/pkg/nitro/env/env_test.go
+++ b/pkg/nitro/env/env_test.go
@@ -1654,10 +1654,11 @@ func TestCreateEnvStatusUnknown(t *testing.T) {
 		t.Fatalf("expected comparison to match:\nRsp: %+v\nExp: %+v", el2, exp)
 	}
 	nt := newNotificationTracker()
-	plf, err := locker.NewPreemptiveLockerFactory(
-		locker.NewFakeLockProvider(),
+	plf, err := locker.NewFakePreemptiveLockerFactory(
+		[]locker.LockProviderOption{
+			locker.WithLockTimeout(2 * time.Second),
+		},
 		locker.WithLockDelay(time.Second),
-		locker.WithLockWait(2*time.Second),
 	)
 	if err != nil {
 		t.Fatalf("error creating new preemptive locker factory: %v", err)

--- a/pkg/nitro/env/env_test.go
+++ b/pkg/nitro/env/env_test.go
@@ -39,7 +39,9 @@ import (
 func TestLockingOperation(t *testing.T) {
 	el := &eventlogger.Logger{DL: persistence.NewFakeDataLayer()}
 	plf, err := locker.NewFakePreemptiveLockerFactory(
-		[]locker.LockProviderOption{locker.WithLockTimeout(time.Second)},
+		[]locker.LockProviderOption{
+			locker.WithLockTimeout(time.Second),
+		},
 		locker.WithLockDelay(time.Millisecond),
 	)
 	if err != nil {
@@ -57,8 +59,8 @@ func TestLockingOperation(t *testing.T) {
 		pl := m.PLF(repo, pr, "new operation")
 		pl.Lock(ctx)
 		releaseCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
 		defer pl.Release(releaseCtx)
+		defer cancel()
 		select {
 		case <-timer.C:
 			return errors.New("timer expired")

--- a/pkg/nitro/env/env_test.go
+++ b/pkg/nitro/env/env_test.go
@@ -38,15 +38,8 @@ import (
 
 func TestLockingOperation(t *testing.T) {
 	el := &eventlogger.Logger{DL: persistence.NewFakeDataLayer()}
-	lp, err := locker.NewLockProvider(
-		locker.FakeLockProviderKind,
-		locker.WithLockWait(time.Second),
-	)
-	if err != nil {
-		t.Fatalf("error creating new lock provider: %v", err)
-	}
-	plf, err := locker.NewPreemptiveLockerFactory(
-		lp,
+	plf, err := locker.NewFakePreemptiveLockerFactory(
+		[]locker.LockProviderOption{locker.WithLockTimeout(time.Second)},
 		locker.WithLockDelay(time.Millisecond),
 	)
 	if err != nil {
@@ -478,16 +471,8 @@ func TestCreate(t *testing.T) {
 				KC: k8sfake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "nitro-1234-some-random-name"}}),
 			}
 			nt := newNotificationTracker()
-			lp, err := locker.NewLockProvider(
-				locker.FakeLockProviderKind,
-				locker.WithLockWait(2*time.Second),
-			)
-			if err != nil {
-				t.Fatalf("error creating new lock provider: %v", err)
-			}
-			plf, err := locker.NewPreemptiveLockerFactory(
-				lp,
-				locker.WithLockDelay(time.Second),
+			plf, err := locker.NewFakePreemptiveLockerFactory(
+				[]locker.LockProviderOption{locker.WithLockTimeout(2 * time.Second)},
 			)
 			if err != nil {
 				t.Fatalf("error creating new preemptive locker factory: %v", err)
@@ -755,15 +740,8 @@ func TestUpdate(t *testing.T) {
 				KC:           k8sfake.NewSimpleClientset(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: c.inputK8sEnv.Namespace}}),
 			}
 			nt := newNotificationTracker()
-			lp, err := locker.NewLockProvider(
-				locker.FakeLockProviderKind,
-				locker.WithLockWait(time.Second),
-			)
-			if err != nil {
-				t.Fatalf("error creating new lock provider: %v", err)
-			}
-			plf, err := locker.NewPreemptiveLockerFactory(
-				lp,
+			plf, err := locker.NewFakePreemptiveLockerFactory(
+				[]locker.LockProviderOption{locker.WithLockTimeout(time.Second)},
 				locker.WithLockDelay(time.Millisecond),
 			)
 			if err != nil {
@@ -927,15 +905,8 @@ func TestDelete(t *testing.T) {
 				DL:           dl,
 				HelmReleases: releases,
 			}
-			lp, err := locker.NewLockProvider(
-				locker.FakeLockProviderKind,
-				locker.WithLockWait(time.Second),
-			)
-			if err != nil {
-				t.Fatalf("error creating new lock provider: %v", err)
-			}
-			plf, err := locker.NewPreemptiveLockerFactory(
-				lp,
+			plf, err := locker.NewFakePreemptiveLockerFactory(
+				[]locker.LockProviderOption{locker.WithLockTimeout(time.Second)},
 				locker.WithLockDelay(time.Millisecond),
 			)
 			if err != nil {

--- a/pkg/reap/reaper.go
+++ b/pkg/reap/reaper.go
@@ -70,7 +70,7 @@ func (r *Reaper) Reap() {
 		r.logger.Printf("error trying to acquire lock: %v", err)
 		return
 	}
-	_, err = lock.Lock(ctx, lockWait)
+	_, err = lock.Lock(ctx)
 	if err != nil {
 		r.logger.Printf("error locking: %v", err)
 		return

--- a/testing/localsecrets/main.go
+++ b/testing/localsecrets/main.go
@@ -130,8 +130,8 @@ func injectFuranSecrets(kc *kubernetes.Clientset, ns string) {
 		ferr("error unmarshaling configmap json: %v", err)
 	}
 
-	secrets["secret/production/furan/github/token"] = getGitHubToken()
-	secrets["secret/production/furan/dockercfg"] = getFuranDockerCfg()
+	secrets["production/furan/github/token"] = getGitHubToken()
+	secrets["production/furan/dockercfg"] = getFuranDockerCfg()
 
 	jdd, err := json.Marshal(&secrets)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/dollarshaveclub/acyl/issues/116


**Summary**
This introduces 2 new fields to the LockProvider implementations. 
1. `MaxLockDuration`: After this duration, the goroutine that manages the state of the Postgres Lock will force the lock to be released. This prevents locks from being held indefinitely, in the event that the holder never calls `Unlock(ctx)`
2. `PreemptionTimeout`: After the postgres lock goroutine receives a notification that the lock should be released, it will immediately send a message over the `preempt` channel returned from the `Lock` method. After the `PreemptionTimeout` duration, it will force the lock to Unlock, in the event the holder doesn't respond. 


**Specifics** 
* Ensure and document that `Unlock` is idempotent, since it might be called multiple times now.
* Create a single factory,`NewLockProvider`, for creating both Fake and Postgres LockProviders. This approach was chosen so that the logic to set default values and perform validation on passed configuration is done in a single function. 
* Reduced the `defaultLockWait` value from 30.5 minutes to 20 seconds, since returning the error more promptly could prevent users from waiting very long in the event there is an issue. Now that we have a `MaxLockDuration` value, this will be the value which protects against leaking the Goroutine or having that particular Goroutine hang.
* Listens for notifications before acquiring the lock. This prevents the lock from potentially missing any notifications while waiting to obtain the lock from Postgres. 
* Updated tests and usages of LockProviders to use the `NewLockProvider` function
* Updated `lockingOperation` method in `env.go` to ensure that it always returns when a context is canceled. This should prevent updates from getting stuck in a pending state and ensure that the lock is explicitly closed. 
