### PR TITLE
Use array of event IDs to retrieve environment events

### DIFF
--- a/migrations/0020_add_event_ids_to_environments_down.sql
+++ b/migrations/0020_add_event_ids_to_environments_down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE environments DROP COLUMN IF EXISTS event_ids;

--- a/migrations/0020_add_event_ids_to_environments_up.sql
+++ b/migrations/0020_add_event_ids_to_environments_up.sql
@@ -1,4 +1,4 @@
-ALTER TABLE qa_environments ADD COLUMN IF NOT EXISTS event_ids uuid[] DEFAULT '{}';
+ALTER TABLE qa_environments ADD COLUMN event_ids uuid[] DEFAULT '{}';
 
 UPDATE qa_environments
 SET event_ids = array(

--- a/migrations/0020_add_event_ids_to_environments_up.sql
+++ b/migrations/0020_add_event_ids_to_environments_up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE qa_environments ADD COLUMN IF NOT EXISTS event_ids uuid[] DEFAULT '{}';
+
+UPDATE qa_environments
+SET event_ids = array(
+    SELECT id FROM event_logs WHERE qa_environments.name = event_logs.env_name
+);

--- a/pkg/models/eventlogs.go
+++ b/pkg/models/eventlogs.go
@@ -32,6 +32,10 @@ func (el EventLog) Columns() string {
 	return strings.Join([]string{"id", "created", "updated", "env_name", "repo", "pull_request", "webhook_payload", "github_delivery_id", "log", "log_key"}, ",")
 }
 
+func (el EventLog) ColumnsWithoutID() string {
+	return strings.Join([]string{"created", "updated", "env_name", "repo", "pull_request", "webhook_payload", "github_delivery_id", "log", "log_key"}, ",")
+}
+
 func (el EventLog) ColumnsWithStatus() string {
 	return strings.Join([]string{"id", "created", "updated", "env_name", "repo", "pull_request", "webhook_payload", "github_delivery_id", "log", "log_key", "status"}, ",")
 }

--- a/pkg/persistence/datalayer_test.go
+++ b/pkg/persistence/datalayer_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"strings"
 	"testing"
@@ -902,9 +901,6 @@ func TestDataLayerGetMostRecentOrdering(t *testing.T) {
 		t.Fatalf("should have returned all envs: %v", qas)
 	}
 	now := time.Now().UTC()
-	for _, qa := range qas {
-		log.Println(qa.Created.String())
-	}
 	for i := 0; i < 5; i++ {
 		got := qas[i].Created.String()
 		expectedPrefix := now.AddDate(0, 0, -i).Format("2006-01-02")

--- a/pkg/persistence/datalayer_test.go
+++ b/pkg/persistence/datalayer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"strings"
 	"testing"
@@ -901,9 +902,14 @@ func TestDataLayerGetMostRecentOrdering(t *testing.T) {
 		t.Fatalf("should have returned all envs: %v", qas)
 	}
 	now := time.Now().UTC()
+	for _, qa := range qas {
+		log.Println(qa.Created.String())
+	}
 	for i := 0; i < 5; i++ {
-		if !strings.HasPrefix(qas[i].Created.String(), now.AddDate(0, 0, -i).Format("2006-01-02")) {
-			t.Fatalf("bad ordering: %v\n", qas)
+		got := qas[i].Created.String()
+		expectedPrefix := now.AddDate(0, 0, -i).Format("2006-01-02")
+		if !strings.HasPrefix(got, expectedPrefix) {
+			t.Fatalf("bad ordering: got %s, expected prefix %s: %v\n", got, expectedPrefix, qas)
 		}
 	}
 }

--- a/pkg/persistence/pg.go
+++ b/pkg/persistence/pg.go
@@ -497,7 +497,7 @@ func (p *PGLayer) GetMostRecent(ctx context.Context, n uint) ([]QAEnvironment, e
 	if isCancelled(ctx) {
 		return nil, errors.Wrap(ctx.Err(), "error getting most recent")
 	}
-	q := `SELECT ` + models.QAEnvironment{}.Columns() + fmt.Sprintf(` from qa_environments WHERE created >= (current_timestamp - interval '%v days');`, n)
+	q := `SELECT ` + models.QAEnvironment{}.Columns() + fmt.Sprintf(` from qa_environments WHERE created >= (current_timestamp - interval '%v days') ORDER BY created DESC;`, n)
 	return p.collectRows(p.db.QueryContext(ctx, q))
 }
 

--- a/pkg/persistence/setupdb_test.go
+++ b/pkg/persistence/setupdb_test.go
@@ -184,6 +184,10 @@ func (tdl *TestDataLayer) insertEventLog(el models.EventLog) error {
 	if _, err := tdl.pgdb.Exec(q, el.Status, el.ID); err != nil {
 		return errors.Wrap(err, "error setting event log status")
 	}
+	q = `UPDATE qa_environments SET event_ids = event_ids || $1::uuid WHERE name = $2`
+	if _, err := tdl.pgdb.Exec(q, el.ID, el.EnvName); err != nil {
+		return errors.Wrap(err, "error setting environment event IDs")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Instead of retrieving event logs by looking up event logs with a given environment name, this PR adds a column event_ids to the qa_environments table that stores the event foreign keys to allow for fast looks. Currently, this PR backfills previous env_name-based data into the new column, and maintains the env_name column in the event_logs table alongside the event_ids array.