### PR TITLE
Move to Go 1.13 error wrapping for nitro and fix error annotation design

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.15
     working_directory: /go/src/github.com/dollarshaveclub/acyl
     steps:
       - checkout
@@ -13,7 +13,7 @@ jobs:
       - run: go build
   test:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
       - image: postgres:9.5.9-alpine
         environment:
         - POSTGRES_USER=acyl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine
+FROM golang:1.15-alpine
 
 COPY . /go/src/github.com/dollarshaveclub/acyl
 RUN cd /go/src/github.com/dollarshaveclub/acyl && \

--- a/pkg/match/match.go
+++ b/pkg/match/match.go
@@ -3,6 +3,8 @@ package match
 
 import (
 	"fmt"
+
+	nitroerrors "github.com/dollarshaveclub/acyl/pkg/nitro/errors"
 )
 
 // BranchInfo includes the information about a specific branch of a git repo
@@ -37,7 +39,7 @@ func GetRefForRepo(ri RepoInfo, branches []BranchInfo) (sha string, branch strin
 		}
 		v, ok := binfo[branch]
 		if !ok {
-			return "", "", fmt.Errorf("branch matching is disabled but repo is missing a '%v' branch", branch)
+			return "", "", nitroerrors.User(fmt.Errorf("branch matching is disabled but repo is missing a '%v' branch", branch))
 		}
 		return v, branch, nil
 	}
@@ -55,7 +57,7 @@ func GetRefForRepo(ri RepoInfo, branches []BranchInfo) (sha string, branch strin
 			fb = ri.BaseBranch
 			fl = "BaseBranch"
 		}
-		return "", "", fmt.Errorf(`no suitable branch: neither "%v" (SourceBranch) nor "%v" (%v) found`, ri.SourceBranch, fb, fl)
+		return "", "", nitroerrors.User(fmt.Errorf(`no suitable branch: neither "%v" (SourceBranch) nor "%v" (%v) found`, ri.SourceBranch, fb, fl))
 	}
 
 	// order determines precedence

--- a/pkg/models/nitro.go
+++ b/pkg/models/nitro.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lib/pq"
 
+	nitroerrors "github.com/dollarshaveclub/acyl/pkg/nitro/errors"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/sha3"
 )
@@ -192,15 +193,15 @@ func (dd DependencyDeclaration) ValidateNames() (bool, error) {
 	checkNames := func(label string, deps []RepoConfigDependency) (bool, error) {
 		for i, d := range deps {
 			if d.Name == "" {
-				return false, fmt.Errorf("empty name at offset %v in %v dependencies", i, label)
+				return false, nitroerrors.User(fmt.Errorf("empty name at offset %v in %v dependencies", i, label))
 			}
 			if _, ok := nm[d.Name]; ok {
-				return false, fmt.Errorf("duplicate name at offset %v in %v dependencies", i, label)
+				return false, nitroerrors.User(fmt.Errorf("duplicate name at offset %v in %v dependencies", i, label))
 			}
 			nm[d.Name] = struct{}{}
 			if d.BranchMatchable() {
 				if _, ok := rm[d.Repo]; ok {
-					return false, fmt.Errorf("duplicate repo dependency at offset %v in %v dependencies: %v", i, label, d.Repo)
+					return false, nitroerrors.User(fmt.Errorf("duplicate repo dependency at offset %v in %v dependencies: %v", i, label, d.Repo))
 				}
 				rm[d.Repo] = struct{}{}
 			}
@@ -208,7 +209,7 @@ func (dd DependencyDeclaration) ValidateNames() (bool, error) {
 		for _, d := range deps {
 			for j, r := range d.Requires {
 				if _, ok := nm[r]; !ok {
-					return false, fmt.Errorf("unknown requirement of %v dependency '%v' at offset %v: %v", label, d.Name, j, r)
+					return false, nitroerrors.User(fmt.Errorf("unknown requirement of %v dependency '%v' at offset %v: %v", label, d.Name, j, r))
 				}
 			}
 		}

--- a/pkg/nitro/env/env.go
+++ b/pkg/nitro/env/env.go
@@ -175,14 +175,14 @@ func (m *Manager) setGithubCommitStatus(ctx context.Context, rd *models.RepoRevi
 	}
 	renderedCSTemplate, err := cst.Render(csData)
 	if err != nil {
-		return nil, errors.Wrap(err, "error rendering template")
+		return nil, fmt.Errorf("error rendering template: %w", err)
 	}
 	eid := eventlogger.GetLogger(ctx).ID
 	if err := m.DL.SetEventStatusRenderedStatus(eid, models.RenderedEventStatus{
 		Description:   renderedCSTemplate.Description,
 		LinkTargetURL: renderedCSTemplate.TargetURL,
 	}); err != nil {
-		return nil, errors.Wrap(err, "error setting event status rendered status")
+		return nil, fmt.Errorf("error setting event status rendered status: %w", err)
 	}
 	turl := renderedCSTemplate.TargetURL
 	if m.UIBaseURL != "" {
@@ -198,7 +198,7 @@ func (m *Manager) setGithubCommitStatus(ctx context.Context, rd *models.RepoRevi
 	ctx2 = ghapp.CloneGitHubClientContext(ctx2, ctx)
 	err = m.RC.SetStatus(ctx2, rd.Repo, rd.SourceSHA, cs)
 	if err != nil {
-		return nil, errors.Wrap(err, "error setting commit status")
+		return nil, fmt.Errorf("error setting commit status: %w", err)
 	}
 	return cs, nil
 }
@@ -212,7 +212,7 @@ func (m *Manager) lockingOperation(ctx context.Context, repo string, pr uint, f 
 	preempt, err := lock.Lock(ctx)
 	if err != nil {
 		end("success:false")
-		return errors.Wrap(err, "error getting lock")
+		return fmt.Errorf("error getting lock: %w", err)
 	}
 	end("success:true")
 	defer func() {
@@ -241,14 +241,19 @@ func (m *Manager) lockingOperation(ctx context.Context, repo string, pr uint, f 
 	cancelled := false
 	select {
 	case opErr := <-ch:
-		err = opErr
+		select {
+		case <-ctx.Done():
+			cancelled = true
+		default:
+			err = opErr
+		}
 	case <-ctx.Done():
 		cancelled = true
 	}
 	switch {
 	case cancelled:
 		eventlogger.GetLogger(ctx).SetCompletedStatus(models.CancelledStatus)
-		err = nitroerrors.CancelledError(ctx.Err())
+		err = nitroerrors.Cancelled(ctx.Err())
 	case err != nil:
 		var ce metahelmlib.ChartError
 		if stdliberrors.As(err, &ce) {
@@ -319,7 +324,7 @@ type newEnv struct {
 
 func (m *Manager) getRepoConfig(ctx context.Context, rd *models.RepoRevisionData) (rc *models.RepoConfig, err error) {
 	if rd == nil {
-		return nil, nitroerrors.SystemError(errors.New("rd is nil"))
+		return nil, errors.New("rd is nil")
 	}
 	m.log(ctx, "fetching and processing environment config")
 	end := m.MC.Timing(mpfx+"process_config", "triggering_repo:"+rd.Repo)
@@ -328,10 +333,10 @@ func (m *Manager) getRepoConfig(ctx context.Context, rd *models.RepoRevisionData
 	}()
 	rc, err = m.MG.Get(ctx, *rd)
 	if err != nil {
-		return nil, errors.Wrap(nitroerrors.UserError(err), "error getting metadata")
+		return nil, fmt.Errorf("error getting metadata: %w", err)
 	}
 	if rc == nil {
-		return nil, nitroerrors.SystemError(errors.New("rc is nil"))
+		return nil, errors.New("rc is nil")
 	}
 	m.MC.Gauge(mpfx+"dependencies", float64(len(rc.Dependencies.All())), "triggering_repo:"+rd.Repo)
 	return rc, nil
@@ -341,14 +346,11 @@ func (m *Manager) getRepoConfig(ctx context.Context, rd *models.RepoRevisionData
 func (m *Manager) generateNewEnv(ctx context.Context, rd *models.RepoRevisionData) (env *models.QAEnvironment, err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "generate_new_env")
 	defer func() {
-		if err != nil {
-			err = nitroerrors.SystemError(err)
-		}
 		span.Finish(tracer.WithError(err))
 	}()
 	envs, err := m.DL.GetQAEnvironmentsByRepoAndPR(ctx, rd.Repo, rd.PullRequest)
 	if err != nil {
-		return nil, errors.Wrap(err, "error checking for existing environment record")
+		return nil, fmt.Errorf("error checking for existing environment record: %w", err)
 	}
 	if len(envs) > 0 {
 		// environment record exists, reuse the latest one
@@ -357,24 +359,24 @@ func (m *Manager) generateNewEnv(ctx context.Context, rd *models.RepoRevisionDat
 		m.log(ctx, "reusing environment db record: %v", env.Name)
 		// update relevant fields
 		if err := m.DL.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Name, models.Spawned); err != nil {
-			return nil, errors.Wrap(err, "error setting environment status")
+			return nil, fmt.Errorf("error setting environment status: %w", err)
 		}
 		m.DL.AddEvent(ctx, env.Name, fmt.Sprintf("reusing environment record for webhook event %v", eventlogger.GetLogger(ctx).ID.String()))
 		if err := m.DL.SetQAEnvironmentRepoData(ctx, env.Name, rd); err != nil {
-			return nil, errors.Wrap(err, "error setting environment repo data")
+			return nil, fmt.Errorf("error setting environment repo data: %w", err)
 		}
 		if err := m.DL.SetQAEnvironmentCreated(ctx, env.Name, time.Now().UTC()); err != nil {
-			return nil, errors.Wrap(err, "error setting environment created timestamp")
+			return nil, fmt.Errorf("error setting environment created timestamp: %w", err)
 		}
 		env, err = m.DL.GetQAEnvironment(ctx, env.Name)
 		if err != nil {
-			return nil, errors.Wrap(err, "error getting updated, reused environment record")
+			return nil, fmt.Errorf("error getting updated, reused environment record: %w", err)
 		}
 	} else {
 		// no record exists, create a new one
 		name, err := m.NG.New()
 		if err != nil {
-			return nil, errors.Wrap(err, "error generating name")
+			return nil, fmt.Errorf("error generating name: %w", err)
 		}
 		m.log(ctx, "generating new environment record: %v", name)
 		env = &models.QAEnvironment{
@@ -391,7 +393,7 @@ func (m *Manager) generateNewEnv(ctx context.Context, rd *models.RepoRevisionDat
 			SourceRef:    rd.SourceRef,
 		}
 		if err = m.DL.CreateQAEnvironment(ctx, env); err != nil {
-			return nil, errors.Wrap(err, "error writing environment to db")
+			return nil, fmt.Errorf("error writing environment to db: %w", err)
 		}
 	}
 	return env, nil
@@ -401,37 +403,34 @@ func (m *Manager) generateNewEnv(ctx context.Context, rd *models.RepoRevisionDat
 func (m *Manager) processEnvConfig(ctx context.Context, env *models.QAEnvironment, rd *models.RepoRevisionData) (ne *newEnv, err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "process_env_config")
 	defer func() {
-		if err != nil && !nitroerrors.IsUserError(err) {
-			err = nitroerrors.SystemError(err)
-		}
 		span.Finish(tracer.WithError(err))
 	}()
 	ne = &newEnv{env: env}
 	rc, err := m.getRepoConfig(ctx, rd)
 	if err != nil {
-		return ne, errors.Wrap(err, "error validating environment config")
+		return ne, fmt.Errorf("error validating environment config: %w", err)
 	}
 	ne.rc = rc
 	rm, err := rc.RefMap()
 	if err != nil {
-		return ne, errors.Wrap(err, "error generating ref map")
+		return ne, fmt.Errorf("error generating ref map: %w", err)
 	}
 	csm, err := rc.CommitSHAMap()
 	if err != nil {
-		return ne, errors.Wrap(err, "error generating commit SHA map")
+		return ne, fmt.Errorf("error generating commit SHA map: %w", err)
 	}
 	if err := m.DL.SetQAEnvironmentRefMap(ctx, env.Name, rm); err != nil {
-		return ne, errors.Wrap(err, "error setting environment ref map")
+		return ne, fmt.Errorf("error setting environment ref map: %w", err)
 	}
 	if err := m.DL.SetQAEnvironmentCommitSHAMap(ctx, env.Name, csm); err != nil {
-		return ne, errors.Wrap(err, "error setting environment commit sha map")
+		return ne, fmt.Errorf("error setting environment commit sha map: %w", err)
 	}
 	if err := m.DL.SetQAEnvironmentRepoData(ctx, env.Name, rd); err != nil {
-		return ne, errors.Wrap(err, "error setting environment repo data")
+		return ne, fmt.Errorf("error setting environment repo data: %w", err)
 	}
 	env, err = m.DL.GetQAEnvironment(ctx, env.Name)
 	if err != nil {
-		return ne, errors.Wrap(err, "error getting updated environment record")
+		return ne, fmt.Errorf("error getting updated environment record: %w", err)
 	}
 	ne.env = env
 	return ne, nil
@@ -444,16 +443,13 @@ func (m *Manager) fetchCharts(ctx context.Context, name string, rc *models.RepoC
 	}()
 	td, err := tempDir(m.FS, "", name)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "error generating temp dir")
+		return "", nil, fmt.Errorf("error generating temp dir: %w", err)
 	}
 	end := m.MC.Timing(mpfx+"fetch_helm_charts", "triggering_repo:"+rc.Application.Repo)
 	cloc, err := m.MG.FetchCharts(ctx, rc, td)
 	if err != nil {
 		end("success:false")
-		if !nitroerrors.IsSystemError(err) {
-			err = nitroerrors.UserError(err)
-		}
-		return "", nil, errors.Wrap(err, "error fetching charts")
+		return "", nil, fmt.Errorf("error fetching charts: %w", err)
 	}
 	end("success:true")
 	return td, cloc, nil
@@ -485,7 +481,7 @@ func (m *Manager) create(ctx context.Context, rd *models.RepoRevisionData) (envn
 	}()
 	env, err := m.generateNewEnv(ctx, rd)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating environment data")
+		return "", fmt.Errorf("error generating environment data: %w", err)
 	}
 	eventlogger.GetLogger(ctx).SetNewStatus(models.CreateEvent, env.Name, *rd)
 	m.setloggername(ctx, env.Name)
@@ -513,13 +509,13 @@ func (m *Manager) create(ctx context.Context, rd *models.RepoRevisionData) (envn
 	start := time.Now().UTC()
 	newenv, err = m.processEnvConfig(ctx, env, rd)
 	if err != nil {
-		return "", errors.Wrap(err, "error processing environment config")
+		return "", fmt.Errorf("error processing environment config: %w", err)
 	}
 	elapsed := time.Since(start)
 	eventlogger.GetLogger(ctx).SetInitialStatus(newenv.rc, elapsed)
 	select {
 	case <-ctx.Done():
-		return "", nitroerrors.UserError(fmt.Errorf("context was cancelled in create"))
+		return "", nitroerrors.User(fmt.Errorf("context was cancelled in create"))
 	default:
 		break
 	}
@@ -527,7 +523,7 @@ func (m *Manager) create(ctx context.Context, rd *models.RepoRevisionData) (envn
 	m.setGithubCommitStatus(ctx, rd, newenv, models.CommitStatusPending, "")
 	td, cloc, err := m.fetchCharts(ctx, env.Name, newenv.rc)
 	if err != nil {
-		return "", errors.Wrap(err, "error fetching charts")
+		return "", fmt.Errorf("error fetching charts: %w", err)
 	}
 	defer billyutil.RemoveAll(m.FS, td)
 	mcloc := metahelm.ChartLocations{}
@@ -539,13 +535,13 @@ func (m *Manager) create(ctx context.Context, rd *models.RepoRevisionData) (envn
 	}
 
 	if err = m.enforceGlobalLimit(ctx); err != nil {
-		return "", errors.Wrap(err, "error enforcing global limit")
+		return "", fmt.Errorf("error enforcing global limit: %w", err)
 	}
 
 	chartSpan, ctx := tracer.StartSpanFromContext(ctx, "build_and_install_charts")
 	if err = m.CI.BuildAndInstallCharts(ctx, &metahelm.EnvInfo{Env: newenv.env, RC: newenv.rc}, mcloc); err != nil {
 		chartSpan.Finish(tracer.WithError(err))
-		return "", errors.Wrap(nitroerrors.UserError(err), "error installing charts")
+		return "", fmt.Errorf("error installing charts: %w", err)
 	}
 	chartSpan.Finish()
 	return newenv.env.Name, nil
@@ -566,7 +562,7 @@ var extantEnvsErr = errors.New("did not find exactly one extant environment")
 func (m *Manager) getenv(ctx context.Context, rd *models.RepoRevisionData) (*models.QAEnvironment, error) {
 	envs, err := m.DL.GetExtantQAEnvironments(ctx, rd.Repo, rd.PullRequest)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting extant environments")
+		return nil, fmt.Errorf("error getting extant environments: %w", err)
 	}
 	if len(envs) != 1 {
 		m.log(ctx, "expected exactly one extant environment but there are %v", len(envs))
@@ -591,7 +587,7 @@ func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reaso
 			m.log(ctx, "no extant envs for destroy request")
 			envs, err := m.DL.GetQAEnvironmentsByRepoAndPR(ctx, rd.Repo, rd.PullRequest)
 			if err != nil {
-				return errors.Wrapf(nitroerrors.SystemError(err), "error getting environments associated with the repo (%v) and PR (%v)", rd.Repo, rd.PullRequest)
+				return fmt.Errorf("error getting environments associated with the repo (%v) and PR (%v): %w", rd.Repo, rd.PullRequest, err)
 			}
 			if len(envs) > 0 {
 				for _, e := range envs {
@@ -603,7 +599,7 @@ func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reaso
 			}
 			return nil
 		}
-		return errors.Wrap(nitroerrors.SystemError(err), "error getting extant environment")
+		return fmt.Errorf("error getting extant environment: %w", err)
 	}
 	eventlogger.GetLogger(ctx).SetNewStatus(models.DestroyEvent, env.Name, *rd)
 	m.setloggername(ctx, env.Name)
@@ -626,14 +622,14 @@ func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reaso
 	}()
 	select {
 	case <-ctx.Done():
-		return nitroerrors.UserError(fmt.Errorf("context was cancelled in delete"))
+		return nitroerrors.User(fmt.Errorf("context was cancelled in delete"))
 	default:
 		break
 	}
 	m.pushNotification(ctx, ne, notifier.DestroyEnvironment, "")
 	k8senv, err := m.DL.GetK8sEnv(ctx, env.Name)
 	if err != nil {
-		return errors.Wrap(nitroerrors.SystemError(err), "error getting k8s environment")
+		return fmt.Errorf("error getting k8s environment: %w", err)
 	}
 	if k8senv == nil {
 		return errors.New("missing k8s environment")
@@ -647,7 +643,7 @@ func (m *Manager) delete(ctx context.Context, rd *models.RepoRevisionData, reaso
 	// use independent context for setting the status
 	err = m.DL.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Name, models.Destroyed)
 	if err != nil {
-		return errors.Wrap(nitroerrors.SystemError(err), "error setting environment status")
+		return fmt.Errorf("error setting environment status: %w", err)
 	}
 	return nil
 }
@@ -708,7 +704,7 @@ func (m *Manager) update(ctx context.Context, rd *models.RepoRevisionData) (envn
 			return m.create(ctx, rd)
 		}
 		eventlogger.GetLogger(ctx).SetCompletedStatus(models.FailedStatus)
-		return "", errors.Wrap(nitroerrors.SystemError(err), "error getting extant environment")
+		return "", fmt.Errorf("error getting extant environment: %w", err)
 	}
 	eventlogger.GetLogger(ctx).SetNewStatus(models.UpdateEvent, env.Name, *rd)
 	m.setloggername(ctx, env.Name)
@@ -734,20 +730,20 @@ func (m *Manager) update(ctx context.Context, rd *models.RepoRevisionData) (envn
 	started := time.Now().UTC()
 	ne, err = m.processEnvConfig(ctx, env, rd)
 	if err != nil {
-		return "", errors.Wrap(err, "error processing environment config for update")
+		return "", fmt.Errorf("error processing environment config for update: %w", err)
 	}
 	elapsed := time.Since(started)
 	eventlogger.GetLogger(ctx).SetInitialStatus(ne.rc, elapsed)
 	k8senv, err := m.DL.GetK8sEnv(ctx, env.Name)
 	if err != nil {
-		return "", errors.Wrap(nitroerrors.SystemError(err), "error getting k8s environment")
+		return "", fmt.Errorf("error getting k8s environment: %w", err)
 	}
 	if k8senv == nil {
-		return "", nitroerrors.SystemError(errors.New("missing k8s environment"))
+		return "", errors.New("missing k8s environment")
 	}
 	select {
 	case <-ctx.Done():
-		return "", nitroerrors.UserError(fmt.Errorf("context was cancelled in update"))
+		return "", nitroerrors.User(fmt.Errorf("context was cancelled in update"))
 	default:
 		break
 	}
@@ -755,7 +751,7 @@ func (m *Manager) update(ctx context.Context, rd *models.RepoRevisionData) (envn
 	m.setGithubCommitStatus(ctx, rd, ne, models.CommitStatusPending, "")
 	td, cloc, err := m.fetchCharts(ctx, env.Name, ne.rc)
 	if err != nil {
-		return "", errors.Wrap(err, "error fetching charts")
+		return "", fmt.Errorf("error fetching charts: %w", err)
 	}
 	defer billyutil.RemoveAll(m.FS, td)
 	mcloc := metahelm.ChartLocations{}
@@ -773,7 +769,7 @@ func (m *Manager) update(ctx context.Context, rd *models.RepoRevisionData) (envn
 		m.MC.Increment(mpfx+"update_in_place", "triggering_repo:"+rd.Repo)
 		releases, err := m.DL.GetHelmReleasesForEnv(ctx, env.Name)
 		if err != nil {
-			return "", errors.Wrap(nitroerrors.SystemError(err), "error getting helm releases for env")
+			return "", fmt.Errorf("error getting helm releases for env: %w", err)
 		}
 		rsls := map[string]string{}
 		for _, r := range releases {
@@ -781,7 +777,7 @@ func (m *Manager) update(ctx context.Context, rd *models.RepoRevisionData) (envn
 		}
 		envinfo.Releases = rsls
 		if err := m.CI.BuildAndUpgradeCharts(ctx, envinfo, k8senv, mcloc); err != nil {
-			return envinfo.Env.Name, errors.Wrap(nitroerrors.UserError(err), "error upgrading charts")
+			return envinfo.Env.Name, fmt.Errorf("error upgrading charts: %w", nitroerrors.User(err))
 		}
 		return envinfo.Env.Name, nil
 	}
@@ -793,7 +789,7 @@ func (m *Manager) update(ctx context.Context, rd *models.RepoRevisionData) (envn
 	chartSpan, ctx := tracer.StartSpanFromContext(ctx, "build_and_install_charts")
 	if err = m.CI.BuildAndInstallCharts(ctx, &metahelm.EnvInfo{Env: ne.env, RC: ne.rc}, mcloc); err != nil {
 		chartSpan.Finish(tracer.WithError(err))
-		return "", errors.Wrap(nitroerrors.UserError(err), "error installing charts")
+		return "", fmt.Errorf("error installing charts: %w", nitroerrors.User(err))
 	}
 	chartSpan.Finish()
 

--- a/pkg/nitro/errors/errors.go
+++ b/pkg/nitro/errors/errors.go
@@ -1,70 +1,53 @@
 package errors
 
-import (
-	"errors"
-)
+import "errors"
 
-type operationError struct {
-	inner                   error
-	user, system, cancelled bool
+type UserError struct {
+	error
 }
 
-func (oe operationError) Error() string {
-	return oe.inner.Error()
+func (err UserError) Error() string {
+	return err.error.Error()
 }
 
-// Implement Unwrap so this error can be friendly for Go's errors.Is and errors.As implementations.
-func (oe operationError) Unwrap() error {
-	return oe.inner
+func (err UserError) Unwrap() error {
+	return err.error
 }
 
-// UserError annotates err in such a way that IsUserError() can be used further up in the callstack.
-func UserError(err error) error {
+func User(err error) error {
 	if err == nil {
 		return nil
 	}
-	return operationError{user: true, inner: err}
+	return UserError{err}
 }
 
-// SystemError annotates err in such a way that IsSystemError() can be used further up in the callstack.
-func SystemError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return operationError{system: true, inner: err}
-}
-
-// CancelledError annotates err in such a way that IsCancelled() can be used further up in the callstack.
-func CancelledError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return operationError{cancelled: true, inner: err}
-}
-
-// IsUserError finds the first nitro error in the chain and returns true if it is a user error.
 func IsUserError(err error) bool {
-	var e operationError
-	if errors.As(err, &e) {
-		return e.user
-	}
-	return false
+	return errors.As(err, &UserError{})
 }
 
-// IsSystemError finds the first nitro error in the chain and returns true if it is a system error.
-func IsSystemError(err error) bool {
-	var e operationError
-	if errors.As(err, &e) {
-		return e.system
-	}
-	return false
+type CancelledError struct {
+	error
 }
 
-// IsCancelledError finds the first nitro error in the chain and returns true if it is an error caused by a cancelled context.
+func (err CancelledError) Error() string {
+	return err.error.Error()
+}
+
+func (err CancelledError) Unwrap() error {
+	return err.error
+}
+
+func Cancelled(err error) error {
+	if err == nil {
+		return nil
+	}
+	return CancelledError{err}
+}
+
 func IsCancelledError(err error) bool {
-	var e operationError
-	if errors.As(err, &e) {
-		return e.cancelled
-	}
-	return false
+	return errors.As(err, &CancelledError{})
+}
+
+func IsSystemError(err error) bool {
+	return !errors.As(err, &UserError{})
 }

--- a/pkg/nitro/errors/errors.go
+++ b/pkg/nitro/errors/errors.go
@@ -2,18 +2,25 @@ package errors
 
 import "errors"
 
+// A UserError wraps an underlying error to annotate it as being caused by
+// user error. The underlying error string is returned directly, meaning the
+// annotation can be detected using errors.As without the annotation affecting
+// how the errors are communicated.
 type UserError struct {
 	error
 }
 
+// Error returns err's underlying error string.
 func (err UserError) Error() string {
 	return err.error.Error()
 }
 
+// Unwrap returns err's underlying error.
 func (err UserError) Unwrap() error {
 	return err.error
 }
 
+// User annotates err as a user error.
 func User(err error) error {
 	if err == nil {
 		return nil
@@ -21,33 +28,42 @@ func User(err error) error {
 	return UserError{err}
 }
 
-func IsUserError(err error) bool {
-	return errors.As(err, &UserError{})
-}
-
+// A CancelledError wraps an underlying error to annotite at as being caused by
+// the cancellation of a context. CancelledErrors are also annotated as
+// UserErrors.
 type CancelledError struct {
 	error
 }
 
+// Error returns err's underlying error string.
 func (err CancelledError) Error() string {
 	return err.error.Error()
 }
 
+// Unwrap returns err's underlying error.
 func (err CancelledError) Unwrap() error {
 	return err.error
 }
 
+// User annotates err as a context cancelled error.
 func Cancelled(err error) error {
 	if err == nil {
 		return nil
 	}
-	return CancelledError{err}
+	return CancelledError{User(err)}
 }
 
+// IsUserError returns whether err is annotated as a user error.
+func IsUserError(err error) bool {
+	return errors.As(err, &UserError{})
+}
+
+// IsCancelledError returns whether err is annotated as a context cancelled error.
 func IsCancelledError(err error) bool {
 	return errors.As(err, &CancelledError{})
 }
 
+// IsSystemError returns whether err is not annotated as a user error.
 func IsSystemError(err error) bool {
 	return !errors.As(err, &UserError{})
 }

--- a/pkg/nitro/images/furan.go
+++ b/pkg/nitro/images/furan.go
@@ -30,7 +30,7 @@ func NewFuranBuilderBackend(addrs []string, dl persistence.DataLayer, mc metrics
 	logger := log.New(logout, "", log.LstdFlags)
 	fc, err := furan.NewFuranClient(fcopts, logger, datadogServiceNamePrefix)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating Furan client")
+		return nil, fmt.Errorf("error creating Furan client: %w", err)
 	}
 	return &FuranBuilderBackend{
 		dl:  dl,
@@ -112,7 +112,7 @@ func (fib *FuranBuilderBackend) BuildImage(ctx context.Context, envName, githubR
 	close(bchan)
 
 	if buildErr != nil {
-		return errors.Wrapf(buildErr, "build failed: %v", githubRepo)
+		return fmt.Errorf("build failed: %v: %w", githubRepo, buildErr)
 	}
 	return nil
 }

--- a/pkg/nitro/images/imagebuild.go
+++ b/pkg/nitro/images/imagebuild.go
@@ -71,7 +71,6 @@ func buildid(envname, name string) string {
 
 // Completed returns if build for repo has completed along with outcome
 func (b *BuildBatch) Completed(envname, name string) (bool, error) {
-	fmt.Println("Completed")
 	b.outcomes.RLock()
 	defer b.outcomes.RUnlock()
 	err, ok := b.outcomes.completed[buildid(envname, name)]

--- a/pkg/nitro/images/imagebuild.go
+++ b/pkg/nitro/images/imagebuild.go
@@ -71,6 +71,7 @@ func buildid(envname, name string) string {
 
 // Completed returns if build for repo has completed along with outcome
 func (b *BuildBatch) Completed(envname, name string) (bool, error) {
+	fmt.Println("Completed")
 	b.outcomes.RLock()
 	defer b.outcomes.RUnlock()
 	err, ok := b.outcomes.completed[buildid(envname, name)]
@@ -119,7 +120,7 @@ func (b *ImageBuilder) StartBuilds(ctx context.Context, envname string, rc *mode
 		eventlogger.GetLogger(ctx).SetImageCompleted(name, err != nil)
 
 		batch.outcomes.Lock()
-		batch.outcomes.completed[buildid(envname, name)] = nitroerrors.UserError(err)
+		batch.outcomes.completed[buildid(envname, name)] = nitroerrors.User(err)
 		batch.outcomes.Unlock()
 	}
 	cfs := []context.CancelFunc{}

--- a/pkg/nitro/meta/meta.go
+++ b/pkg/nitro/meta/meta.go
@@ -13,10 +13,11 @@ import (
 	"time"
 
 	"github.com/dollarshaveclub/acyl/pkg/eventlogger"
+	nitroerrors "github.com/dollarshaveclub/acyl/pkg/nitro/errors"
+
 	"github.com/dollarshaveclub/acyl/pkg/ghclient"
 	"github.com/dollarshaveclub/acyl/pkg/match"
 	"github.com/dollarshaveclub/acyl/pkg/models"
-	nitroerrors "github.com/dollarshaveclub/acyl/pkg/nitro/errors"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	billy "gopkg.in/src-d/go-billy.v4"
@@ -54,13 +55,13 @@ func (g DataGetter) GetAcylYAML(ctx context.Context, rc *models.RepoConfig, repo
 	log(ctx, "fetching acyl.yml for %v@%v", repo, ref)
 	b, err := g.RC.GetFileContents(ctx, repo, "acyl.yml", ref)
 	if err != nil {
-		return errors.Wrap(err, "error getting acyl.yml")
+		return fmt.Errorf("error getting acyl.yml: %w", err)
 	}
 	if err := yaml.Unmarshal(b, &rc); err != nil {
-		return errors.Wrap(err, "error unmarshaling acyl.yml")
+		return nitroerrors.User(fmt.Errorf("error unmarshaling acyl.yml: %w", err))
 	}
 	if rc.Version < 2 {
-		return ErrUnsupportedVersion
+		return nitroerrors.User(ErrUnsupportedVersion)
 	}
 	rc.Application.SetValueDefaults()
 	rc.Application.Repo = repo
@@ -75,21 +76,21 @@ func (g DataGetter) getChartName(ctx context.Context, repo, ref, path string) (_
 		}
 	}()
 	if repo == "" || ref == "" || path == "" {
-		return "", fmt.Errorf("one of repo (%v), ref (%v) or path (%v) is empty", repo, ref, path)
+		return "", nitroerrors.User(fmt.Errorf("one of repo (%v), ref (%v) or path (%v) is empty", repo, ref, path))
 	}
 	log(ctx, "getting file contents: %v@%v: %v", repo, ref, path+"/Chart.yaml")
 	b, err := g.RC.GetFileContents(ctx, repo, path+"/Chart.yaml", ref)
 	if err != nil {
-		return "", errors.Wrap(err, "error getting Chart.yaml")
+		return "", fmt.Errorf("error getting Chart.yaml: %w", err)
 	}
 	cd := struct {
 		Name string `yaml:"name"`
 	}{}
 	if err := yaml.Unmarshal(b, &cd); err != nil {
-		return "", errors.Wrap(err, "error unmarshaling Chart.yaml")
+		return "", nitroerrors.User(fmt.Errorf("error unmarshaling Chart.yaml: %w", err))
 	}
 	if cd.Name == "" {
-		return "", errors.New("chart name field is empty")
+		return "", nitroerrors.User(errors.New("chart name field is empty"))
 	}
 	return cd.Name, nil
 }
@@ -103,7 +104,7 @@ func (g DataGetter) getDependencyChartName(ctx context.Context, d *models.RepoCo
 		log(ctx, "chart name for dependency: %v", cname)
 	}()
 	if d == nil {
-		return "", errors.New("dependency is nil")
+		return "", nitroerrors.User(errors.New("dependency is nil"))
 	}
 	var crepo, cref, cpath string
 	switch {
@@ -112,11 +113,11 @@ func (g DataGetter) getDependencyChartName(ctx context.Context, d *models.RepoCo
 	case d.AppMetadata.ChartRepoPath != "":
 		rp := &repoPath{}
 		if err := rp.parseFromString(d.AppMetadata.ChartRepoPath); err != nil {
-			return "", errors.Wrapf(err, "error parsing ChartRepoPath for repo dependency: %v", d.Repo)
+			return "", fmt.Errorf("error parsing ChartRepoPath for repo dependency: %v: %w", d.Repo, err)
 		}
 		crepo, cref, cpath = rp.repo, rp.ref, rp.path
 	default:
-		return "", fmt.Errorf("repo dependency lacks ChartPath/ChartRepoPath: %v", d.Repo)
+		return "", nitroerrors.User(fmt.Errorf("repo dependency lacks ChartPath/ChartRepoPath: %v", d.Repo))
 	}
 	return g.getChartName(ctx, crepo, cref, cpath)
 }
@@ -130,12 +131,12 @@ func (g DataGetter) getRefForRepoDependency(ctx context.Context, d *models.RepoC
 		log(ctx, "calculated ref for repo dependency: %v: %v (%v)", d.Repo, branch, sha)
 	}()
 	if d == nil || d.Repo == "" {
-		return "", "", errors.New("empty Repo field")
+		return "", "", nitroerrors.User(errors.New("empty Repo field"))
 	}
 	log(ctx, "fetching branches for %v", d.Repo)
 	branches, err := g.RC.GetBranches(ctx, d.Repo)
 	if err != nil {
-		return "", "", errors.Wrap(err, "error getting repo branches")
+		return "", "", fmt.Errorf("error getting repo branches: %w", err)
 	}
 	bi := make([]match.BranchInfo, len(branches))
 	for i := range branches {
@@ -153,7 +154,7 @@ func (g DataGetter) getRefForRepoDependency(ctx context.Context, d *models.RepoC
 	}
 	sha, branch, err = match.GetRefForRepo(ri, bi)
 	if err != nil {
-		return "", "", errors.Wrap(err, "error getting ref for repo")
+		return "", "", fmt.Errorf("error getting ref for repo: %w", err)
 	}
 	// get override if present, but only override the SHA
 	if override, ok := g.RepoRefOverrides[d.Repo]; ok {
@@ -211,18 +212,18 @@ func (g DataGetter) Get(ctx context.Context, rd models.RepoRevisionData) (*model
 		log(ctx, "processing dependency: %v (parent: %v, ancestor: %v)", d.Name, parent.Name, ancestor.Name)
 		select {
 		case <-ctx.Done():
-			return errors.New("context was cancelled")
+			return nitroerrors.Cancelled(errors.New("context was cancelled"))
 		default:
 			break
 		}
 		switch {
 		case d.Repo != "" && (d.ChartPath != "" || d.ChartRepoPath != ""):
-			return fmt.Errorf("dependency error: %v: only one of Repo, ChartPath, or ChartRepoPath may be used", d.Name)
+			return nitroerrors.User(fmt.Errorf("dependency error: %v: only one of Repo, ChartPath, or ChartRepoPath may be used", d.Name))
 		case d.ChartPath != "" && d.ChartRepoPath != "":
-			return fmt.Errorf("dependency error: %v: either ChartPath or ChartRepoPath may be used, not both", d.Name)
+			return nitroerrors.User(fmt.Errorf("dependency error: %v: either ChartPath or ChartRepoPath may be used, not both", d.Name))
 		case d.Repo != "":
 			if _, ok := repomap[d.Repo]; ok {
-				return fmt.Errorf("duplicate repository dependency: %v (check for circular dependency declarations)", d.Repo)
+				return nitroerrors.User(fmt.Errorf("duplicate repository dependency: %v (check for circular dependency declarations)", d.Repo))
 			}
 			repomap[d.Repo] = struct{}{}
 			bm := !ancestor.DisableBranchMatch
@@ -232,18 +233,18 @@ func (g DataGetter) Get(ctx context.Context, rd models.RepoRevisionData) (*model
 			}
 			dref, dbranch, err := g.getRefForRepoDependency(ctx, d, rd, defb, bm)
 			if err != nil {
-				return errors.Wrapf(err, "error getting ref for repo dependency: %v", d.Repo)
+				return fmt.Errorf("error getting ref for repo dependency: %v: %w", d.Repo, err)
 			}
 			drc := models.RepoConfig{}
 			if err := g.GetAcylYAML(ctx, &drc, d.Repo, dref); err != nil {
-				return errors.Wrapf(err, "error processing %v acyl.yml", d.Repo)
+				return fmt.Errorf("error processing %v acyl.yml: %w", d.Repo, err)
 			}
 			drc.Application.Branch = dbranch
 			d.AppMetadata = drc.Application
 			if d.Name == "" {
 				name, err := g.getDependencyChartName(ctx, d)
 				if err != nil {
-					return errors.Wrapf(err, "error getting chart name for repo dependency: %v", d.Repo)
+					return fmt.Errorf("error getting chart name for repo dependency: %v: %w", d.Repo, err)
 				}
 				d.Name = name
 			}
@@ -253,7 +254,7 @@ func (g DataGetter) Get(ctx context.Context, rd models.RepoRevisionData) (*model
 			for i := range drc.Dependencies.Direct {
 				dd := &drc.Dependencies.Direct[i]
 				if err := processDep(dd, d, ancestor); err != nil {
-					return errors.Wrapf(err, "error processing direct dependency of %v: %v", d.Name, dd.Name)
+					return fmt.Errorf("error processing direct dependency of %v: %v: %w", d.Name, dd.Name, err)
 				}
 				old, new := dd.Name, models.GetName(d.Repo)+"-"+dd.Name
 				dd.Name = new
@@ -269,13 +270,13 @@ func (g DataGetter) Get(ctx context.Context, rd models.RepoRevisionData) (*model
 
 		case d.ChartPath != "" || d.ChartRepoPath != "":
 			if d.DisableBranchMatch || d.DefaultBranch != "" {
-				return fmt.Errorf("branch matching and default branch not available if ChartPath or ChartRepoPath is used: %v", d.Name)
+				return nitroerrors.User(fmt.Errorf("branch matching and default branch not available if ChartPath or ChartRepoPath is used: %v", d.Name))
 			}
 			var drepo, dref, dbranch string
 			if d.ChartPath == "" {
 				rp := &repoPath{}
 				if err := rp.parseFromString(d.ChartRepoPath); err != nil {
-					return errors.Wrapf(err, "dependency error: %v: malformed ChartRepoPath", d.Name)
+					return fmt.Errorf("dependency error: %v: malformed ChartRepoPath: %w", d.Name, err)
 				}
 				drepo = rp.repo
 				dref = rp.ref
@@ -296,7 +297,7 @@ func (g DataGetter) Get(ctx context.Context, rd models.RepoRevisionData) (*model
 			if d.Name == "" {
 				name, err := g.getDependencyChartName(ctx, d)
 				if err != nil {
-					return errors.Wrapf(err, "error getting chart name for dependency: %v", d.AppMetadata.Repo)
+					return fmt.Errorf("error getting chart name for dependency: %v: %w", d.AppMetadata.Repo, err)
 				}
 				d.Name = name
 			}
@@ -308,7 +309,7 @@ func (g DataGetter) Get(ctx context.Context, rd models.RepoRevisionData) (*model
 	}
 	rc := models.RepoConfig{}
 	if err := g.GetAcylYAML(ctx, &rc, rd.Repo, rd.SourceSHA); err != nil {
-		return nil, errors.Wrap(err, "error processing target repo acyl.yml")
+		return nil, fmt.Errorf("error processing target repo acyl.yml: %w", err)
 	}
 	repomap[rd.Repo] = struct{}{}
 	rc.Application.Branch = rd.SourceBranch
@@ -316,7 +317,7 @@ func (g DataGetter) Get(ctx context.Context, rd models.RepoRevisionData) (*model
 	for i := range rc.Dependencies.Direct {
 		d := &rc.Dependencies.Direct[i]
 		if err := processDep(d, parent, d); err != nil {
-			return nil, errors.Wrap(err, "error processing direct dependencies")
+			return nil, fmt.Errorf("error processing direct dependencies: %w", err)
 		}
 	}
 	for _, td := range transitiveDeps {
@@ -327,7 +328,7 @@ func (g DataGetter) Get(ctx context.Context, rd models.RepoRevisionData) (*model
 	for i := range rc.Dependencies.Environment {
 		d := &rc.Dependencies.Environment[i]
 		if err := processDep(d, parent, d); err != nil {
-			return nil, errors.Wrap(err, "error processing environment dependencies")
+			return nil, fmt.Errorf("error processing environment dependencies: %w", err)
 		}
 	}
 	for _, td := range transitiveDeps {
@@ -335,7 +336,7 @@ func (g DataGetter) Get(ctx context.Context, rd models.RepoRevisionData) (*model
 	}
 
 	if ok, err := rc.Dependencies.ValidateNames(); !ok {
-		return nil, errors.Wrap(err, "error validating dependency names")
+		return nil, fmt.Errorf("error validating dependency names: %w", err)
 	}
 	return &rc, nil
 }
@@ -349,19 +350,19 @@ func (rp *repoPath) parseFromString(crp string) error {
 	// chart_repo_path: dollarshaveclub/helm-charts@master:path/to/chart
 	psl := strings.Split(crp, ":")
 	if len(psl) != 2 {
-		return fmt.Errorf("malformed repo path: exactly one ':'' required: %v", crp)
+		return nitroerrors.User(fmt.Errorf("malformed repo path: exactly one ':'' required: %v", crp))
 	}
 	rp.path = psl[1]
 	if strings.Contains(psl[0], "@") {
 		rsl := strings.Split(psl[0], "@")
 		if len(rsl) != 2 {
-			return fmt.Errorf("malformed repo path: no more than one '@' may be present: %v", psl[0])
+			return nitroerrors.User(fmt.Errorf("malformed repo path: no more than one '@' may be present: %v", psl[0]))
 		}
 		rp.ref = rsl[1]
 		psl[0] = rsl[0]
 	}
 	if len(strings.Split(psl[0], "/")) != 2 {
-		return fmt.Errorf("malformed repo: exactly one '/' is required: %v", psl[0])
+		return nitroerrors.User(fmt.Errorf("malformed repo: exactly one '/' is required: %v", psl[0]))
 	}
 	rp.repo = psl[0]
 	return nil
@@ -377,12 +378,12 @@ func getChartLocation(d models.RepoConfigDependency) (chartLocation, error) {
 	loc := chartLocation{}
 	if d.AppMetadata.ChartPath == "" {
 		if d.AppMetadata.ChartRepoPath == "" {
-			return loc, errors.New("one of ChartPath or ChartRepoPath must be defined")
+			return loc, nitroerrors.User(errors.New("one of ChartPath or ChartRepoPath must be defined"))
 		}
 		rp := &repoPath{}
 		err := rp.parseFromString(d.AppMetadata.ChartRepoPath)
 		if err != nil {
-			return loc, errors.Wrap(err, "error validating ChartRepoPath")
+			return loc, fmt.Errorf("error validating ChartRepoPath: %w", err)
 		}
 		loc.chart = *rp
 	} else {
@@ -399,7 +400,7 @@ func getChartLocation(d models.RepoConfigDependency) (chartLocation, error) {
 		rp := &repoPath{}
 		err := rp.parseFromString(d.AppMetadata.ChartVarsRepoPath)
 		if err != nil {
-			return loc, errors.Wrap(err, "error validating ChartVarsRepoPath")
+			return loc, fmt.Errorf("error validating ChartVarsRepoPath: %w", err)
 		}
 		loc.vars = *rp
 	}
@@ -430,36 +431,36 @@ func (g DataGetter) FetchCharts(ctx context.Context, rc *models.RepoConfig, base
 		out := &ChartLocation{ValueOverrides: make(map[string]string)}
 		cloc, err := getChartLocation(d)
 		if err != nil {
-			return nil, errors.Wrap(err, "error getting chart location")
+			return nil, fmt.Errorf("error getting chart location: %w", err)
 		}
 		cd := path.Join(basePath, strconv.Itoa(i), d.Name)
 		log(ctx, "getting directory contents: %v@%v: %v", cloc.chart.repo, cloc.chart.ref, cloc.chart.path)
 		dc, err := g.RC.GetDirectoryContents(ctx, cloc.chart.repo, cloc.chart.path, cloc.chart.ref)
 		if err != nil {
-			return nil, errors.Wrap(err, "error fetching chart contents")
+			return nil, fmt.Errorf("error fetching chart contents: %w", err)
 		}
 		for n, c := range dc {
 			n = strings.Replace(n, filepath.Clean(cloc.chart.path), "", -1) // remove chart path
 			fp := path.Join(cd, n)
 			if err = g.FS.MkdirAll(path.Dir(fp), os.ModePerm); err != nil {
-				return nil, errors.Wrap(nitroerrors.SystemError(err), "error creating directory")
+				return nil, fmt.Errorf("error creating directory: %w", err)
 			}
 			if c.Symlink {
 				if err := g.FS.Symlink(c.SymlinkTarget, fp); err != nil {
-					return nil, errors.Wrap(nitroerrors.SystemError(err), "error creating symlink")
+					return nil, fmt.Errorf("error creating symlink: %w", err)
 				}
 				continue
 			}
 			f, err := g.FS.Create(fp)
 			if err != nil {
-				return nil, errors.Wrap(nitroerrors.SystemError(err), "error creating file")
+				return nil, fmt.Errorf("error creating file: %w", err)
 			}
 			defer f.Close()
 			var n int
 			for {
 				i, err := f.Write(c.Contents[n:len(c.Contents)])
 				if err != nil {
-					return nil, errors.Wrap(nitroerrors.SystemError(err), "error writing to file")
+					return nil, fmt.Errorf("error writing to file: %w", err)
 				}
 				n += i
 				if n == len(c.Contents) {
@@ -472,20 +473,20 @@ func (g DataGetter) FetchCharts(ctx context.Context, rc *models.RepoConfig, base
 			log(ctx, "getting file contents: %v@%v: %v", cloc.vars.repo, cloc.vars.ref, cloc.vars.path)
 			fc, err := g.RC.GetFileContents(ctx, cloc.vars.repo, cloc.vars.path, cloc.vars.ref)
 			if err != nil {
-				return nil, errors.Wrap(err, "error getting vars file")
+				return nil, fmt.Errorf("error getting vars file: %w", err)
 			}
 			vcd := path.Join(cd, "vars.yml")
 			vf, err := g.FS.Create(vcd)
 			if err != nil {
-				return nil, errors.Wrap(nitroerrors.SystemError(err), "error creating vars file")
+				return nil, fmt.Errorf("error creating vars file: %w", err)
 			}
 			defer vf.Close()
 			n, err := vf.Write(fc)
 			if err != nil {
-				return nil, errors.Wrap(nitroerrors.SystemError(err), "error writing to vars file")
+				return nil, fmt.Errorf("error writing to vars file: %w", err)
 			}
 			if n < len(fc) {
-				return nil, nitroerrors.SystemError(io.ErrShortWrite)
+				return nil, io.ErrShortWrite
 			}
 			for _, v := range d.AppMetadata.ValueOverrides {
 				vsl := strings.SplitN(v, "=", 2)
@@ -501,7 +502,7 @@ func (g DataGetter) FetchCharts(ctx context.Context, rc *models.RepoConfig, base
 	name := models.GetName(rc.Application.Repo)
 	loc, err := fetchChartAndVars(0, models.RepoConfigDependency{Name: name, AppMetadata: rc.Application})
 	if err != nil || loc == nil {
-		return nil, errors.Wrap(err, "error getting primary repo chart")
+		return nil, fmt.Errorf("error getting primary repo chart: %w", err)
 	}
 	out := map[string]ChartLocation{name: *loc}
 	ctx, cf := context.WithTimeout(ctx, 2*time.Minute)
@@ -516,14 +517,14 @@ func (g DataGetter) FetchCharts(ctx context.Context, rc *models.RepoConfig, base
 		eg.Go(func() error {
 			loc, err = fetchChartAndVars(i+1, d)
 			if err != nil || loc == nil {
-				return errors.Wrapf(err, "error getting dependency chart: %v", d.Name)
+				return fmt.Errorf("error getting dependency chart: %v: %w", d.Name, err)
 			}
 			couts[i] = *loc
 			return nil
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		return nil, errors.Wrap(err, "error fetching charts")
+		return nil, fmt.Errorf("error fetching charts: %w", err)
 	}
 	for i := 0; i < rc.Dependencies.Count(); i++ {
 		loc := couts[i]
@@ -531,7 +532,7 @@ func (g DataGetter) FetchCharts(ctx context.Context, rc *models.RepoConfig, base
 		for _, v := range d.ValueOverrides { // Dependency value_overrides override anything in the application metadata
 			vsl := strings.SplitN(v, "=", 2)
 			if len(vsl) != 2 {
-				return nil, fmt.Errorf("malformed value override: %v", v)
+				return nil, nitroerrors.User(fmt.Errorf("malformed value override: %v", v))
 			}
 			loc.ValueOverrides[vsl[0]] = vsl[1]
 		}

--- a/pkg/nitro/meta/meta_test.go
+++ b/pkg/nitro/meta/meta_test.go
@@ -17,13 +17,13 @@ import (
 func readFiles() (map[string][]byte, error) {
 	files, err := ioutil.ReadDir("./testdata/")
 	if err != nil {
-		return nil, errors.Wrap(err, "error reading directory")
+		return nil, fmt.Errorf("error reading directory: %w", err)
 	}
 	out := make(map[string][]byte, len(files))
 	for _, f := range files {
 		d, err := ioutil.ReadFile("./testdata/" + f.Name())
 		if err != nil {
-			return nil, errors.Wrapf(err, "error reading file: %v", f.Name())
+			return nil, fmt.Errorf("error reading file: %v: %w", f.Name(), err)
 		}
 		out[f.Name()] = d
 	}

--- a/pkg/nitro/metahelm/metahelm.go
+++ b/pkg/nitro/metahelm/metahelm.go
@@ -305,7 +305,7 @@ func (ci ChartInstaller) BuildAndInstallChartsIntoExisting(ctx context.Context, 
 func (ci ChartInstaller) installOrUpgradeIntoExisting(ctx context.Context, env *EnvInfo, k8senv *models.KubernetesEnvironment, cl ChartLocations, upgrade bool) (err error) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "chart_installer.install_or_upgrade")
 	if ci.kc == nil {
-		return nitroerrors.User(errors.New("k8s client is nil"))
+		return errors.New("k8s client is nil")
 	}
 	ci.dl.SetQAEnvironmentStatus(tracer.ContextWithSpan(context.Background(), span), env.Env.Name, models.Updating)
 	defer func() {

--- a/pkg/nitro/metahelm/metahelm_test.go
+++ b/pkg/nitro/metahelm/metahelm_test.go
@@ -110,7 +110,7 @@ func TestMetahelmGenerateCharts(t *testing.T) {
 				checkOverrideString := func(overrides []byte, name, value string) error {
 					om := map[string]interface{}{}
 					if err := yaml.Unmarshal(overrides, &om); err != nil {
-						return errors.Wrap(err, "error unmarshaling overrides")
+						return fmt.Errorf("error unmarshaling overrides: %w", err)
 					}
 					vi, ok := om[name]
 					if !ok {
@@ -127,19 +127,19 @@ func TestMetahelmGenerateCharts(t *testing.T) {
 				}
 				for _, chart := range charts {
 					if err := checkOverrideString(chart.ValueOverrides, models.DefaultNamespaceValue, "fake-name"); err != nil {
-						return errors.Wrap(err, "error checking override")
+						return fmt.Errorf("error checking override: %w", err)
 					}
 				}
 				chart := cm["foo-bar"]
 				if err := checkOverrideString(chart.ValueOverrides, "something", "qqqq"); err != nil {
-					return errors.Wrap(err, "error checking something override")
+					return fmt.Errorf("error checking something override: %w", err)
 				}
 				chart = cm["bar-baz"]
 				if err := checkOverrideString(chart.ValueOverrides, "somethingelse", "zzzz"); err != nil {
-					return errors.Wrap(err, "error checking somethingelse override")
+					return fmt.Errorf("error checking somethingelse override: %w", err)
 				}
 				if err := checkOverrideString(chart.ValueOverrides, "yetanotherthing", "yyyy"); err != nil {
-					return errors.Wrap(err, "error checking yetanotherthing override")
+					return fmt.Errorf("error checking yetanotherthing override: %w", err)
 				}
 				return nil
 			},

--- a/pkg/nitro/metahelm/readall.go
+++ b/pkg/nitro/metahelm/readall.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
 	billy "gopkg.in/src-d/go-billy.v4"
 )
 
@@ -14,7 +13,7 @@ var fileSizeMaxBytes = 500 * 1000000 // we won't try to read files larger than t
 func readFileSafely(fs billy.Filesystem, fp string) ([]byte, error) {
 	fi, err := fs.Stat(fp)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting file info")
+		return nil, fmt.Errorf("error getting file info: %w", err)
 	}
 	if fi.Size() > int64(fileSizeMaxBytes) {
 		return nil, fmt.Errorf("file size exceeds limit (%v bytes): %v", fileSizeMaxBytes, fi.Size())

--- a/pkg/nitro/metrics/metrics.go
+++ b/pkg/nitro/metrics/metrics.go
@@ -1,10 +1,10 @@
 package metrics
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/pkg/errors"
 )
 
 // Collector describes an object that collects metrics
@@ -25,7 +25,7 @@ var _ Collector = &DatadogCollector{}
 func NewDatadogCollector(namespace, addr string, tags []string) (*DatadogCollector, error) {
 	c, err := statsd.New(addr)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating statsd client")
+		return nil, fmt.Errorf("error creating statsd client: %w", err)
 	}
 	c.Namespace = namespace
 	c.Tags = tags

--- a/pkg/nitro/notifier/slack.go
+++ b/pkg/nitro/notifier/slack.go
@@ -1,9 +1,10 @@
 package notifier
 
 import (
+	"fmt"
+
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/nlopes/slack"
-	"github.com/pkg/errors"
 )
 
 // SlackAPIClient describes the methods we use on slack.Client
@@ -24,7 +25,7 @@ var _ Backend = &SlackBackend{}
 func (sb *SlackBackend) Send(n Notification) error {
 	p, err := sb.render(n)
 	if err != nil || p == nil {
-		return errors.Wrap(err, "error rendering notification")
+		return fmt.Errorf("error rendering notification: %w", err)
 	}
 	p.Username = sb.Username
 	p.IconURL = sb.IconURL
@@ -51,7 +52,7 @@ func (sb *SlackBackend) Send(n Notification) error {
 func (sb *SlackBackend) render(n Notification) (*slack.PostMessageParameters, error) {
 	rn, err := n.Template.Render(n.Data)
 	if err != nil {
-		return nil, errors.Wrap(err, "error rendering template")
+		return nil, fmt.Errorf("error rendering template: %w", err)
 	}
 	out := &slack.PostMessageParameters{Text: rn.Title, Attachments: make([]slack.Attachment, len(rn.Sections))}
 	for i, s := range rn.Sections {

--- a/pkg/nitro/notifier/slack_test.go
+++ b/pkg/nitro/notifier/slack_test.go
@@ -39,7 +39,7 @@ func TestSlackRender(t *testing.T) {
 			},
 			verifyf: func(in *slack.PostMessageParameters, err error) error {
 				if err != nil {
-					return errors.Wrap(err, "should have succeeded")
+					return fmt.Errorf("should have succeeded: %w", err)
 				}
 				if in == nil {
 					return errors.New("result is nil")
@@ -75,7 +75,7 @@ func TestSlackRender(t *testing.T) {
 					return errors.New("should have failed")
 				}
 				if !strings.Contains(err.Error(), "error rendering template") {
-					return errors.Wrap(err, "unexpected error")
+					return fmt.Errorf("unexpected error: %w", err)
 				}
 				return nil
 			},

--- a/pkg/nitro/notifier/term.go
+++ b/pkg/nitro/notifier/term.go
@@ -45,7 +45,7 @@ func (tb *TerminalBackend) Send(n Notification) error {
 	}
 	rn, err := n.Template.Render(n.Data)
 	if err != nil {
-		return errors.Wrap(err, "error rendering template")
+		return fmt.Errorf("error rendering template: %w", err)
 	}
 	rmargin := int(tb.Margin)
 


### PR DESCRIPTION
After reviewing the documentation and examples for Go 1.13 error wrapping, I believe that this adjustment to the error handling in Nitro represents the clearest way to distinguish user errors (and cancellation errors) from regular (system) errors.

pkg/nitro/errors replace the `operationError` type with a `UserError` and `CancelledError` type that wrap generic errors via their constructors `User(err error) error` and `Cancelled(err error) error`, which implement both the `Error() string` and `Unwrap() error` methods. The `Error` method simply returns the underlying error string, while the `Unwrap` method returns the underlying error. This means that existing error format strings will not change if they are wrapped (annotated) as user or cancellation errors, but will still be detectable as user errors via `errors.As`. For example,

```golang
err := errors.New("foo")
err1 := nitroerrors.User(err)
err2 := fmt.Errorf("bar: %w", err1)
fmt.Println(err2)
fmt.Println(errors.As(err2, &nitroerrors.UserError{})
```

will print

    bar: foo
    true

so existing errors can just be annotated once wherever it makes sense, and the existing error strings will be unaffected. This also means that errors are annotated exactly where their category can be distinguished, rather than having to maintain a list of many explicit errors in the `errors` package.

The IsUserError, IsSystemError, and IsCancelledError functions still exist, but these functions are just thin wrappers over `errors.As`, and the two can be used interchangeably; I think they're worth keeping for clarity.

This PR also moves the CircleCI and main Docker images to Go 1.15.