### PR TITLE
Use private ECR image for tiller

### DIFF
--- a/.helm/charts/acyl/templates/cronjob.yaml
+++ b/.helm/charts/acyl/templates/cronjob.yaml
@@ -47,4 +47,8 @@ spec:
               - "{{ .Values.app.cleanup.destroyed_envs_max_age }}"
               - "--event-logs-max-age"
               - "{{ .Values.app.cleanup.event_logs_max_age }}"
+            {{ if .Values.app.tiller_image }}
+              - "--tiller-image"
+              - "{{ .Values.app.tiller_image }}"
+            {{ end }}
 {{ end }}

--- a/.helm/charts/acyl/values.yaml
+++ b/.helm/charts/acyl/values.yaml
@@ -31,6 +31,7 @@ app:
   k8s_secret_injections: "image-pull-secret=k8s/image_pull_secret"
   k8s_client_disable_http2: true # work around bug in using HTTP2 for k8s client calls
   operation_timeout_override: ''
+  tiller_image: ''
   ui:
     base_url: 'http://localhost:4000'
     enforce_oauth: false

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -77,7 +77,7 @@ func cleanup(cmd *cobra.Command, args []string) {
 
 	cleaner.Clean()
 
-	ci, err := metahelm.NewChartInstaller(nil, dl, nil, nil, k8sConfig.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, k8sConfig.SecretInjections, metahelm.TillerConfig{}, k8sClientConfig.JWTPath, true)
+	ci, err := metahelm.NewChartInstaller(nil, dl, nil, nil, k8sConfig.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, k8sConfig.SecretInjections, tillerConfig, k8sClientConfig.JWTPath, true)
 	if err != nil {
 		log.Fatalf("error getting metahelm chart installer: %v", err)
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -245,7 +245,7 @@ func configCheck(cmd *cobra.Command, args []string) {
 		perr("error fetching charts: %v", err)
 		return
 	}
-	ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil)
+	ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil, tillerConfig)
 	if err != nil {
 		perr("error creating chart installer: %v", err)
 		return
@@ -773,7 +773,7 @@ func displayInfoTerminal(rc *models.RepoConfig, err error, mg meta.Getter) int {
 			errorModal("Error Processing Charts", "Check your chart configuration.", err)
 			return
 		}
-		ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil)
+		ci, err := metahelm.NewChartInstallerWithoutK8sClient(nil, nil, osfs.New(""), &metrics.FakeCollector{}, nil, nil, nil, tillerConfig)
 		if err != nil {
 			errorModal("Error Instantiating Chart Installer", "Bug!", err)
 			return

--- a/cmd/integration.go
+++ b/cmd/integration.go
@@ -297,7 +297,7 @@ func setupNitro(dl persistence.DataLayer, useGHToken bool) (spawner.EnvironmentS
 	fs := osfs.New("")
 	mg := &meta.DataGetter{RC: rc, FS: fs}
 	ib := &images.FakeImageBuilder{BatchCompletedFunc: func(envname, repo string) (bool, error) { return true, nil }}
-	ci, err := metahelm.NewChartInstaller(ib, dl, fs, mc, map[string]string{}, []string{}, map[string]config.K8sSecret{}, metahelm.TillerConfig{}, k8sClientConfig.JWTPath, false)
+	ci, err := metahelm.NewChartInstaller(ib, dl, fs, mc, map[string]string{}, []string{}, map[string]config.K8sSecret{}, tillerConfig, k8sClientConfig.JWTPath, false)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error getting metahelm chart installer")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/dollarshaveclub/acyl/pkg/config"
+	"github.com/dollarshaveclub/acyl/pkg/nitro/metahelm"
 	"github.com/dollarshaveclub/acyl/pkg/secrets"
 	"github.com/dollarshaveclub/pvc"
 	"github.com/spf13/cobra"
@@ -21,6 +22,8 @@ var vaultConfig config.VaultConfig
 var secretsConfig config.SecretsConfig
 var secretsbackend string
 var k8sClientConfig config.K8sClientConfig
+var tillerImageName string
+var tillerConfig metahelm.TillerConfig
 
 var RootCmd = &cobra.Command{
 	Use:   "acyl",
@@ -43,6 +46,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&secretsbackend, "secrets-backend", "vault", "Secret backend (one of: vault,env)")
 	RootCmd.PersistentFlags().StringVar(&secretsConfig.Mapping, "secrets-mapping", "", "Secrets mapping template string (required)")
 	RootCmd.PersistentFlags().StringVar(&k8sClientConfig.JWTPath, "k8s-jwt-path", "/var/run/secrets/kubernetes.io/serviceaccount/token", "Path to the JWT used to authenticate the k8s client to the API server")
+	RootCmd.PersistentFlags().StringVar(&tillerConfig.Image, "tiller-image", "helmpack/tiller:v2.17.0", "Name of Tiller image to use when installing charts")
 }
 
 func clierr(msg string, params ...interface{}) {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -182,7 +182,7 @@ func server(cmd *cobra.Command, args []string) {
 	if err := k8sConfig.ProcessSecretInjections(sc, k8sSecretsStr); err != nil {
 		log.Fatalf("error in k8s secret injections: %v", err)
 	}
-	ci, err := metahelm.NewChartInstaller(ib, dl, fs, nmc, k8sConfig.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, k8sConfig.SecretInjections, metahelm.TillerConfig{}, k8sClientConfig.JWTPath, true)
+	ci, err := metahelm.NewChartInstaller(ib, dl, fs, nmc, k8sConfig.GroupBindings, k8sConfig.PrivilegedRepoWhitelist, k8sConfig.SecretInjections, tillerConfig, k8sClientConfig.JWTPath, true)
 	if err != nil {
 		log.Fatalf("error getting metahelm chart installer: %v", err)
 	}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -390,10 +390,9 @@ func testConfigSetup(dl persistence.DataLayer) (*nitroenv.Manager, context.Conte
 	if testEnvCfg.privileged {
 		testEnvCfg.k8sCfg.PrivilegedRepoWhitelist = []string{ri.GitHubRepoName}
 	}
-	tcfg := metahelm.TillerConfig{
-		ServerConnectRetries:    10,
-		ServerConnectRetryDelay: 2 * time.Second,
-	}
+	tcfg := tillerConfig
+	tcfg.ServerConnectRetries = 10
+	tcfg.ServerConnectRetryDelay = 2 * time.Second
 	ci, err := metahelm.NewChartInstallerWithClientsetFromContext(ib, dl, fs, mc, testEnvCfg.k8sCfg.GroupBindings, testEnvCfg.k8sCfg.PrivilegedRepoWhitelist, testEnvCfg.k8sCfg.SecretInjections, tcfg, testEnvCfg.kubeCfgPath, testEnvCfg.kubeCtx)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "error getting chart installer")

--- a/pkg/nitro/metahelm/metahelm.go
+++ b/pkg/nitro/metahelm/metahelm.go
@@ -77,7 +77,7 @@ type K8sClientFactoryFunc func(kubecfgpath, kubectx string) (*kubernetes.Clients
 
 // Defaults for Tiller configuration options, if not specified otherwise
 const (
-	DefaultTillerImage                   = "helmpack/tiller:v2.17.0"
+	DefaultTillerImage                   = "932427637498.dkr.ecr.us-west-2.amazonaws.com/tiller:v2.17.0"
 	DefaultTillerPort                    = 44134
 	DefaultTillerDeploymentName          = "tiller-deploy"
 	DefaultTillerServerConnectRetryDelay = 10 * time.Second

--- a/pkg/nitro/metahelm/metahelm.go
+++ b/pkg/nitro/metahelm/metahelm.go
@@ -77,7 +77,7 @@ type K8sClientFactoryFunc func(kubecfgpath, kubectx string) (*kubernetes.Clients
 
 // Defaults for Tiller configuration options, if not specified otherwise
 const (
-	DefaultTillerImage                   = "932427637498.dkr.ecr.us-west-2.amazonaws.com/tiller:v2.17.0"
+	DefaultTillerImage                   = "helmpack/tiller:v2.17.0"
 	DefaultTillerPort                    = 44134
 	DefaultTillerDeploymentName          = "tiller-deploy"
 	DefaultTillerServerConnectRetryDelay = 10 * time.Second
@@ -155,10 +155,11 @@ func NewChartInstaller(ib images.Builder, dl persistence.DataLayer, fs billy.Fil
 }
 
 // NewChartInstallerWithoutK8sClient returns a ChartInstaller without a k8s client, for use in testing/CLI.
-func NewChartInstallerWithoutK8sClient(ib images.Builder, dl persistence.DataLayer, fs billy.Filesystem, mc metrics.Collector, k8sGroupBindings map[string]string, k8sRepoWhitelist []string, k8sSecretInjs map[string]config.K8sSecret) (*ChartInstaller, error) {
+func NewChartInstallerWithoutK8sClient(ib images.Builder, dl persistence.DataLayer, fs billy.Filesystem, mc metrics.Collector, k8sGroupBindings map[string]string, k8sRepoWhitelist []string, k8sSecretInjs map[string]config.K8sSecret, tcfg TillerConfig) (*ChartInstaller, error) {
 	return &ChartInstaller{
 		ib:               ib,
 		hcf:              NewInClusterHelmClient,
+		tcfg:             tcfg.SetDefaults(),
 		dl:               dl,
 		fs:               fs,
 		mc:               mc,


### PR DESCRIPTION
The Tiller image name for Nitro is now configurable via the CLI with the `--tiller-image` flag and via the `Values.app.tiller_image` field via Helm. This flag defaults to `helmpack/tiller:v2.17.0` from Docker Hub, and we will set the image to the private ECR copy in helm-charts to avoid rate-limiting. The integration test uses Docker Hub as we'd have to be running it over 80 times per hour unauthenticated to hit the limit.