### PR TITLE
Use tiller-image flag in deployment.yaml in Helm chart

### DIFF
--- a/.helm/charts/acyl/templates/deployment.yaml
+++ b/.helm/charts/acyl/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
           - "--vault-k8s-auth-path"
           - "{{ .Values.vault.auth_path }}"
         {{ end }}
+        {{ if .Values.app.tiller_image }}
+          - "--tiller-image"
+          - "{{ .Values.app.tiller_image }}"
+        {{ end }}
     {{ if eq .Values.app.debug_endpoints true }}
           - "--debug-endpoints"
     {{ end }}


### PR DESCRIPTION
Just noticed that the update to the deployment.yaml to add the new tiller-image configuration was excluded from the last push. This PR adds the change.