### PR TITLE
GitHub content downloading fix and retries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	golang.org/x/net v0.0.0-20211013171255-e13a2654a71e
 	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11
 	google.golang.org/grpc v1.41.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.29.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c

--- a/go.sum
+++ b/go.sum
@@ -2068,6 +2068,8 @@ golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 h1:GZokNIeuVkl3aZHJchRrr13WCsols02MLUcz1U9is6M=
+golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/ghclient/github_client_test.go
+++ b/pkg/ghclient/github_client_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	testingRepo = "dollarshaveclub/acyl"
-	testingPath = "vendor/"
+	testingPath = ".helm/charts/acyl"
 	testingRef  = "master"
 )
 

--- a/pkg/ghclient/github_client_test.go
+++ b/pkg/ghclient/github_client_test.go
@@ -2,15 +2,21 @@ package ghclient
 
 import (
 	"context"
+	"fmt"
+	"github.com/palantir/go-githubapp/githubapp"
 	"golang.org/x/sync/errgroup"
+	"io/ioutil"
+	"net"
+	"net/http"
 	"os"
 	"strconv"
 	"testing"
+	"time"
 )
 
 const (
 	testingRepo = "dollarshaveclub/acyl"
-	testingPath = ".helm/charts/acyl"
+	testingPath = ".helm/charts"
 	testingRef  = "master"
 )
 
@@ -31,6 +37,78 @@ func TestGetDirectoryContents(t *testing.T) {
 	for i := 0; i < pcnt; i++ {
 		eg.Go(func() error {
 			_, err := ghc.GetDirectoryContents(context.Background(), testingRepo, testingPath, testingRef)
+			return err
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+}
+
+var (
+	GitHubV3APIURL = "https://api.github.com/"
+	GitHubV4APIURL = "https://api.github.com/graphql"
+	appIDs         = os.Getenv("TEST_GH_APP_ID")
+	instIDs        = os.Getenv("TEST_GH_INST_ID")
+	pkeyPEMPath    = os.Getenv("TEST_GH_APP_PKEY")
+	webhookSecret  = os.Getenv("TEST_GH_APP_WHSECRET")
+)
+
+func TestGetDirectoryContentsGithubApp(t *testing.T) {
+	appID, err := strconv.Atoi(appIDs)
+	if err != nil {
+		t.Fatalf("invalid app id: %v", err)
+	}
+	instID, err := strconv.Atoi(instIDs)
+	if err != nil {
+		t.Fatalf("invalid installation id: %v", err)
+	}
+	privateKeyPEM, err := ioutil.ReadFile(pkeyPEMPath)
+	if err != nil {
+		t.Fatalf("error reading pem key: %v", err)
+	}
+	c := githubapp.Config{}
+	c.V3APIURL = GitHubV3APIURL
+	c.V4APIURL = GitHubV4APIURL
+	c.App.IntegrationID = int64(appID)
+	c.App.PrivateKey = string(privateKeyPEM)
+	c.App.WebhookSecret = webhookSecret
+	tr := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 60 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout: 60 * time.Second,
+	}
+	cc, err := githubapp.NewDefaultCachingClientCreator(c,
+		githubapp.WithClientTimeout(60*time.Second),
+		githubapp.WithTransport(tr))
+	if err != nil {
+		t.Fatalf("error creating GH app client creator: %v", err)
+	}
+	gc, err := cc.NewInstallationClient(int64(instID))
+	if err != nil {
+		t.Fatalf("error getting app client: %v", err)
+	}
+	ghc := NewGitHubClient(token)
+	ghc.c = gc
+
+	pcnt, err := strconv.Atoi(parallelism)
+	if err != nil || pcnt < 1 || pcnt > 1000 {
+		pcnt = 5
+	}
+
+	t.Logf("running with %v calls in parallel...", pcnt)
+
+	eg := errgroup.Group{}
+	for i := 0; i < pcnt; i++ {
+		j := i
+		eg.Go(func() error {
+			fc, err := ghc.GetDirectoryContents(context.Background(), testingRepo, testingPath, testingRef)
+			for k, v := range fc {
+				if len(v.Contents) == 0 {
+					fmt.Printf("EMPTY: %v: %v", j, k)
+				}
+			}
 			return err
 		})
 	}

--- a/pkg/ghclient/github_client_test.go
+++ b/pkg/ghclient/github_client_test.go
@@ -55,6 +55,9 @@ var (
 )
 
 func TestGetDirectoryContentsGithubApp(t *testing.T) {
+	if appIDs == "" || os.Getenv("CIRCLECI") == "true" {
+		t.Skip()
+	}
 	appID, err := strconv.Atoi(appIDs)
 	if err != nil {
 		t.Fatalf("invalid app id: %v", err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -683,7 +683,8 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
-# golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
+# golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11
+## explicit
 golang.org/x/time/rate
 # golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 golang.org/x/xerrors


### PR DESCRIPTION
Switch to [DownloadContents](https://pkg.go.dev/github.com/google/go-github/v42/github#RepositoriesService.DownloadContents) since raw.githubusercontent.com is now failing for private repos. Implement retries since we're also seeing sporadic 503s.

Fixes #176